### PR TITLE
Add script to generate the official-images library manifest file

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -15,17 +15,16 @@ for version in "${versions[@]}"; do
 	commit="$(git log -1 --format='format:%H' -- "$version")"
 	
 	mavenVersion="$(grep -m1 'ENV MAVEN_VERSION ' "$version/Dockerfile" | cut -d' ' -f3)"
-	jdkVersion="$(awk -F '-|:| ' '$1 == "FROM" && $2 == "java" && $3 == "openjdk" { print $4 }' "$version/Dockerfile")"
 	
 	versionAliases=()
 	while [ "${mavenVersion%[.-]*}" != "$mavenVersion" ]; do
-		versionAliases+=( $mavenVersion-jdk-$jdkVersion $mavenVersion-$version )
+		versionAliases+=( $mavenVersion-$version )
 		if [ "$version" = "$latest" ]; then
 			versionAliases+=( $mavenVersion )
 		fi
 		mavenVersion="${mavenVersion%[.-]*}"
 	done
-	versionAliases+=( $mavenVersion-jdk-$jdkVersion $mavenVersion-$version )
+	versionAliases+=( $mavenVersion-$version )
 	if [ "$version" = "$latest" ]; then
 		versionAliases+=( $mavenVersion latest )
 	fi


### PR DESCRIPTION
Usage:

``` console
$ ./generate-stackbrew-library.sh > /path/to/official-images/library/maven
$ cd /path/to/official-images
$ # make a PR out of the changes \o/
```

Example output:

``` console
$ ./generate-stackbrew-library.sh
# maintainer: Carlos Sanchez <carlos@apache.org> (@carlossg)

3.2.5-jdk-6: git://github.com/carlossg/docker-maven@f7b5c6e868367cf05311a9883c0cda908edf808c jdk-6
3.2-jdk-6: git://github.com/carlossg/docker-maven@f7b5c6e868367cf05311a9883c0cda908edf808c jdk-6
3-jdk-6: git://github.com/carlossg/docker-maven@f7b5c6e868367cf05311a9883c0cda908edf808c jdk-6

3.2.5-jdk-6-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-6/onbuild
3.2-jdk-6-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-6/onbuild
3-jdk-6-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-6/onbuild

3.2.5-jdk-7: git://github.com/carlossg/docker-maven@f7b5c6e868367cf05311a9883c0cda908edf808c jdk-7
3.2.5: git://github.com/carlossg/docker-maven@f7b5c6e868367cf05311a9883c0cda908edf808c jdk-7
3.2-jdk-7: git://github.com/carlossg/docker-maven@f7b5c6e868367cf05311a9883c0cda908edf808c jdk-7
3.2: git://github.com/carlossg/docker-maven@f7b5c6e868367cf05311a9883c0cda908edf808c jdk-7
3-jdk-7: git://github.com/carlossg/docker-maven@f7b5c6e868367cf05311a9883c0cda908edf808c jdk-7
3: git://github.com/carlossg/docker-maven@f7b5c6e868367cf05311a9883c0cda908edf808c jdk-7
latest: git://github.com/carlossg/docker-maven@f7b5c6e868367cf05311a9883c0cda908edf808c jdk-7

3.2.5-jdk-7-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-7/onbuild
3.2.5-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-7/onbuild
3.2-jdk-7-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-7/onbuild
3.2-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-7/onbuild
3-jdk-7-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-7/onbuild
3-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-7/onbuild
onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-7/onbuild

3.2.5-jdk-8: git://github.com/carlossg/docker-maven@596e9014bba56dae2a0bdac69b4f5492bc95dad5 jdk-8
3.2-jdk-8: git://github.com/carlossg/docker-maven@596e9014bba56dae2a0bdac69b4f5492bc95dad5 jdk-8
3-jdk-8: git://github.com/carlossg/docker-maven@596e9014bba56dae2a0bdac69b4f5492bc95dad5 jdk-8

3.2.5-jdk-8-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-8/onbuild
3.2-jdk-8-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-8/onbuild
3-jdk-8-onbuild: git://github.com/carlossg/docker-maven@b022df671b603a9100ed9e75803ae32f753826a4 jdk-8/onbuild
```
