### PR TITLE
Force downloads to be over SSL

### DIFF
--- a/jdk-7/Dockerfile
+++ b/jdk-7/Dockerfile
@@ -2,7 +2,7 @@ FROM java:openjdk-7-jdk
 
 ENV MAVEN_VERSION 3.3.3
 
-RUN curl -fsSL http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share \
+RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share \
   && mv /usr/share/apache-maven-$MAVEN_VERSION /usr/share/maven \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 

--- a/jdk-8/Dockerfile
+++ b/jdk-8/Dockerfile
@@ -2,7 +2,7 @@ FROM java:openjdk-8-jdk
 
 ENV MAVEN_VERSION 3.3.3
 
-RUN curl -fsSL http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share \
+RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share \
   && mv /usr/share/apache-maven-$MAVEN_VERSION /usr/share/maven \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 


### PR DESCRIPTION
All downloads should happen over SSL (and even better verified in some way),
otherwise the images can easily get compromised.
