### PR TITLE
Define USER, WORKDIR and ENTRYPOINT in master Maven images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,17 @@ reporting and documentation from a central piece of information.
 Put this file in the root of your project, next to the pom.xml.
 
 This image includes multiple ONBUILD triggers which should be all you need to bootstrap.
-The build will `COPY . /usr/src/app` and `RUN mvn install`.
+The build will `COPY . /maven/project` and `RUN mvn install`.
+
+CMD directive above should contain argumetns to second `mvn` invocation after `mnv install` is
+complete, for example:
+
+    CMD ["-Pdeployment", "-DskipTests=true", "deploy"]
 
 You can then build and run the image:
 
     docker build -t my-maven .
-    docker run -it --name my-maven-script my-maven
+    docker run --rm my-maven
 
 
 ## Run a single Maven command
@@ -40,8 +45,16 @@ For many simple projects, you may find it inconvenient to write a complete `Dock
 In such cases, you can run a Maven project by using the Maven Docker image directly,
 passing a Maven command to `docker run`:
 
-    docker run -it --rm --name my-maven-project -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven maven:3.3-jdk-7 mvn clean install
+    docker run --rm -v $HOME/.m2:/maven/.m2 -v $(pwd):/maven/project maven:3.3-jdk-7 clean install
 
+Note that entry point of the image is `mvn`, so the command you pass to `docker run` are actually
+Maven invocation arguments. In case you need to override it, you can use `--entrypoint` parameter
+of `docker run` command.
+
+The build will be executed as user `maven` with UID 1000. This is important because the mounted
+host directories will be accessed using the same local UID. If the UID of the account used to
+run Docker is different, you need to add `-u $UID` to `docker run` invocation. Otherwise Maven will
+not be able to to write files in `$HOME/.m2` and project `target` directory.
 
 # User Feedback
 

--- a/jdk-7/Dockerfile
+++ b/jdk-7/Dockerfile
@@ -8,6 +8,12 @@ RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/bina
 
 ENV MAVEN_HOME /usr/share/maven
 
-VOLUME /root/.m2
+RUN adduser --disabled-password maven --gecos Maven --home /maven && mkdir /maven/project
 
-CMD ["mvn"]
+USER maven
+
+VOLUME ["/maven/.m2", "/maven/project"]
+
+WORKDIR /maven/project
+
+ENTRYPOINT ["mvn"]

--- a/jdk-7/onbuild/Dockerfile
+++ b/jdk-7/onbuild/Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3-jdk-7
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
-ONBUILD ADD . /usr/src/app
+ONBUILD ADD . /maven/project
 
 ONBUILD RUN mvn install

--- a/jdk-8/Dockerfile
+++ b/jdk-8/Dockerfile
@@ -8,6 +8,12 @@ RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/bina
 
 ENV MAVEN_HOME /usr/share/maven
 
-VOLUME /root/.m2
+RUN adduser --disabled-password maven --gecos Maven --home /maven && mkdir /maven/project
 
-CMD ["mvn"]
+USER maven
+
+VOLUME ["/maven/.m2", "/maven/project"]
+
+WORKDIR /maven/project
+
+ENTRYPOINT ["mvn"]

--- a/jdk-8/onbuild/Dockerfile
+++ b/jdk-8/onbuild/Dockerfile
@@ -1,8 +1,5 @@
 FROM maven:3-jdk-8
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
-ONBUILD ADD . /usr/src/app
+ONBUILD ADD . /maven/project
 
 ONBUILD RUN mvn install


### PR DESCRIPTION
This follows Maven's convention over configuration practice and allows
shortening Docker invocation lines.