### PR TITLE
Prevent failure when not running as root.

### DIFF
--- a/jdk-8/mvn-entrypoint.sh
+++ b/jdk-8/mvn-entrypoint.sh
@@ -22,9 +22,14 @@ copy_reference_file() {
 
 copy_reference_files() {
   local log="$MAVEN_CONFIG/copy_reference_file.log"
-  touch "${log}" || (echo "Can not write to ${log}. Wrong volume permissions?" && exit 1)
-  echo "--- Copying files at $(date)" >> "$log"
-  find /usr/share/maven/ref/ -type f -exec bash -eu -c 'copy_reference_file /usr/share/maven/ref/ "$1" "$2"' _ {} "$log" \;
+
+  if (touch "${log}" > /dev/null 2>&1)
+  then
+      echo "--- Copying files at $(date)" >> "$log"
+      find /usr/share/maven/ref/ -type f -exec bash -eu -c 'copy_reference_file /usr/share/maven/ref/ "$1" "$2"' _ {} "$log" \;
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
 }
 
 export -f copy_reference_file

--- a/jdk-9/mvn-entrypoint.sh
+++ b/jdk-9/mvn-entrypoint.sh
@@ -22,9 +22,14 @@ copy_reference_file() {
 
 copy_reference_files() {
   local log="$MAVEN_CONFIG/copy_reference_file.log"
-  touch "${log}" || (echo "Can not write to ${log}. Wrong volume permissions?" && exit 1)
-  echo "--- Copying files at $(date)" >> "$log"
-  find /usr/share/maven/ref/ -type f -exec bash -eu -c 'copy_reference_file /usr/share/maven/ref/ "$1" "$2"' _ {} "$log" \;
+
+  if (touch "${log}" > /dev/null 2>&1)
+  then
+      echo "--- Copying files at $(date)" >> "$log"
+      find /usr/share/maven/ref/ -type f -exec bash -eu -c 'copy_reference_file /usr/share/maven/ref/ "$1" "$2"' _ {} "$log" \;
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
 }
 
 export -f copy_reference_file

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -27,6 +27,13 @@ load test_helpers
   assert_line -p "Apache Maven $version "
 }
 
+@test "$SUT_TAG create test container (-u 11337:11337)" {
+  version="$(grep 'ARG MAVEN_VERSION' $BATS_TEST_DIRNAME/../$SUT_TAG/Dockerfile | sed -e 's/ARG MAVEN_VERSION=//')"
+  run docker run --rm -u 11337:11337 $SUT_IMAGE mvn -version
+  assert_success
+  assert_line -p "Apache Maven $version "
+}
+
 @test "$SUT_TAG settings.xml is setup" {
   run bash -c "docker run --rm $SUT_TEST_IMAGE cat /root/.m2/settings.xml | diff $BATS_TEST_DIRNAME/settings.xml -"
   assert_success
@@ -36,3 +43,14 @@ load test_helpers
   run docker run --rm $SUT_TEST_IMAGE test -f /root/.m2/repository/junit/junit/3.8.1/junit-3.8.1.jar
   assert_success
 }
+
+@test "$SUT_TAG generate sample project" {
+  run bash -c "docker run --rm -it $SUT_TEST_IMAGE mvn -B archetype:generate -DgroupId=bats-testing -DartifactId=bats-test-project -DarchetypeArtifactId=maven-archetype-quickstart"
+  assert_success
+}
+
+@test "$SUT_TAG generate sample project (-u 11337:11337 -w /tmp --tmpfs /tmp -e HOME=/tmp)" {
+  run bash -c "docker run --rm -it -u 11337:11337 -w /tmp --tmpfs /tmp -e HOME=/tmp $SUT_TEST_IMAGE mvn -B archetype:generate -DgroupId=bats-testing -DartifactId=bats-test-project -DarchetypeArtifactId=maven-archetype-quickstart"
+  assert_success
+}
+


### PR DESCRIPTION
Modify the entry-point script to emit a warning when unable to write to `$MAVEN_CONFIG` directory and then carry on. This should allow for the previous `docker.inside` behavior to once again function correctly.

- [x] add unit test to cover executing `mvn -v` as a non-default user.
- [x] add unit test to cover executing `mvn archetype:generate` as a non-default user.
