### PR TITLE
install rpm package for rpm-maven-plugin

### DIFF
--- a/jdk-8/Dockerfile
+++ b/jdk-8/Dockerfile
@@ -12,6 +12,11 @@ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && rm -f /tmp/apache-maven.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
+# update list of available packages --adds 16MB
+RUN apt-get update
+# install RPM utilities (includes rpmbuild) --adds 18MB
+RUN apt-get install rpm -y
+
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 


### PR DESCRIPTION
(increases Docker image size by 34MB --new size 782MB)

Supports `pom.xml` files containing this dependency:

                    <groupId>org.codehaus.mojo</groupId>
                    <artifactId>rpm-maven-plugin</artifactId>