### PR TITLE
section about docker build -t local_image

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ passing a Maven command to `docker run`:
 
     docker run -it --rm --name my-maven-project -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven maven:3.3-jdk-8 mvn clean install
 
+## Building local Docker image (optional)
+
+This is a base image that you can extend, so it has the bare minimum packages needed. If you add custom package(s) to the `Dockerfile`, then you can build your local Docker image like this:
+
+    docker build --tag my_local_maven:3.5.0-jdk-8 .
 
 # Reusing the Maven local repository
 


### PR DESCRIPTION
added:

## Building local Docker image(s)

This is a base image that you can extend, so it has the bare minimum packages needed. If you add custom package(s) to the `Dockerfile`, then you can build your local Docker image like this:

    docker build --tag my_local_maven:3.5.0-jdk-8_rpm .