### PR TITLE
Add jdk-*-slim versions

### DIFF
--- a/jdk-7-slim/Dockerfile
+++ b/jdk-7-slim/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:7-jdk-slim
+
+ARG MAVEN_VERSION=3.5.0
+ARG USER_HOME_DIR="/root"
+ARG SHA=beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN apt-get update && \
+    apt-get install -y \
+      curl \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY settings-docker.xml /usr/share/maven/ref/
+
+VOLUME "$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/jdk-7-slim/mvn-entrypoint.sh
+++ b/jdk-7-slim/mvn-entrypoint.sh
@@ -1,0 +1,39 @@
+#! /bin/bash -eu
+
+set -o pipefail
+
+# Copy files from /usr/share/maven/ref into ${MAVEN_CONFIG}
+# So the initial ~/.m2 is set with expected content.
+# Don't override, as this is just a reference setup
+copy_reference_file() {
+  local root="${1}"
+  local f="${2%/}"
+  local logfile="${3}"
+  local rel="${f/${root}/}" # path relative to /usr/share/maven/ref/
+  echo "$f" >> "$logfile"
+  echo " $f -> $rel" >> "$logfile"
+  if [[ ! -e ${MAVEN_CONFIG}/${rel} || $f = *.override ]]
+  then
+    echo "copy $rel to ${MAVEN_CONFIG}" >> "$logfile"
+    mkdir -p "${MAVEN_CONFIG}/$(dirname "${rel}")"
+    cp -r "${f}" "${MAVEN_CONFIG}/${rel}";
+  fi;
+}
+
+copy_reference_files() {
+  local log="$MAVEN_CONFIG/copy_reference_file.log"
+
+  if (touch "${log}" > /dev/null 2>&1)
+  then
+      echo "--- Copying files at $(date)" >> "$log"
+      find /usr/share/maven/ref/ -type f -exec bash -eu -c 'copy_reference_file /usr/share/maven/ref/ "$1" "$2"' _ {} "$log" \;
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
+}
+
+export -f copy_reference_file
+copy_reference_files
+unset MAVEN_CONFIG
+
+exec "$@"

--- a/jdk-7-slim/settings-docker.xml
+++ b/jdk-7-slim/settings-docker.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>

--- a/jdk-8-slim/Dockerfile
+++ b/jdk-8-slim/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:8-jdk-slim
+
+ARG MAVEN_VERSION=3.5.0
+ARG USER_HOME_DIR="/root"
+ARG SHA=beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN apt-get update && \
+    apt-get install -y \
+      curl \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY settings-docker.xml /usr/share/maven/ref/
+
+VOLUME "$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/jdk-8-slim/mvn-entrypoint.sh
+++ b/jdk-8-slim/mvn-entrypoint.sh
@@ -1,0 +1,39 @@
+#! /bin/bash -eu
+
+set -o pipefail
+
+# Copy files from /usr/share/maven/ref into ${MAVEN_CONFIG}
+# So the initial ~/.m2 is set with expected content.
+# Don't override, as this is just a reference setup
+copy_reference_file() {
+  local root="${1}"
+  local f="${2%/}"
+  local logfile="${3}"
+  local rel="${f/${root}/}" # path relative to /usr/share/maven/ref/
+  echo "$f" >> "$logfile"
+  echo " $f -> $rel" >> "$logfile"
+  if [[ ! -e ${MAVEN_CONFIG}/${rel} || $f = *.override ]]
+  then
+    echo "copy $rel to ${MAVEN_CONFIG}" >> "$logfile"
+    mkdir -p "${MAVEN_CONFIG}/$(dirname "${rel}")"
+    cp -r "${f}" "${MAVEN_CONFIG}/${rel}";
+  fi;
+}
+
+copy_reference_files() {
+  local log="$MAVEN_CONFIG/copy_reference_file.log"
+
+  if (touch "${log}" > /dev/null 2>&1)
+  then
+      echo "--- Copying files at $(date)" >> "$log"
+      find /usr/share/maven/ref/ -type f -exec bash -eu -c 'copy_reference_file /usr/share/maven/ref/ "$1" "$2"' _ {} "$log" \;
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
+}
+
+export -f copy_reference_file
+copy_reference_files
+unset MAVEN_CONFIG
+
+exec "$@"

--- a/jdk-8-slim/settings-docker.xml
+++ b/jdk-8-slim/settings-docker.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>

--- a/jdk-9-slim/Dockerfile
+++ b/jdk-9-slim/Dockerfile
@@ -1,0 +1,34 @@
+FROM openjdk:9-jdk-slim
+
+ARG MAVEN_VERSION=3.5.0
+ARG USER_HOME_DIR="/root"
+ARG SHA=beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN apt-get update && \
+    apt-get install -y \
+      curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# Maven fails with 'Can't read cryptographic policy directory: unlimited'
+# because it looks for $JAVA_HOME/conf/security/policy/unlimited but it is in
+# /etc/java-9-openjdk/security/policy/unlimited
+RUN ln -s /etc/java-9-openjdk /usr/lib/jvm/java-9-openjdk-amd64/conf
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY settings-docker.xml /usr/share/maven/ref/
+
+VOLUME "$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/jdk-9-slim/mvn-entrypoint.sh
+++ b/jdk-9-slim/mvn-entrypoint.sh
@@ -1,0 +1,39 @@
+#! /bin/bash -eu
+
+set -o pipefail
+
+# Copy files from /usr/share/maven/ref into ${MAVEN_CONFIG}
+# So the initial ~/.m2 is set with expected content.
+# Don't override, as this is just a reference setup
+copy_reference_file() {
+  local root="${1}"
+  local f="${2%/}"
+  local logfile="${3}"
+  local rel="${f/${root}/}" # path relative to /usr/share/maven/ref/
+  echo "$f" >> "$logfile"
+  echo " $f -> $rel" >> "$logfile"
+  if [[ ! -e ${MAVEN_CONFIG}/${rel} || $f = *.override ]]
+  then
+    echo "copy $rel to ${MAVEN_CONFIG}" >> "$logfile"
+    mkdir -p "${MAVEN_CONFIG}/$(dirname "${rel}")"
+    cp -r "${f}" "${MAVEN_CONFIG}/${rel}";
+  fi;
+}
+
+copy_reference_files() {
+  local log="$MAVEN_CONFIG/copy_reference_file.log"
+
+  if (touch "${log}" > /dev/null 2>&1)
+  then
+      echo "--- Copying files at $(date)" >> "$log"
+      find /usr/share/maven/ref/ -type f -exec bash -eu -c 'copy_reference_file /usr/share/maven/ref/ "$1" "$2"' _ {} "$log" \;
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
+}
+
+export -f copy_reference_file
+copy_reference_files
+unset MAVEN_CONFIG
+
+exec "$@"

--- a/jdk-9-slim/settings-docker.xml
+++ b/jdk-9-slim/settings-docker.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>


### PR DESCRIPTION
There is an ongoing work to provide a slimmer version of the debian based image, openjdk already has a version based on this one, so it could be interesting to have a slim version of the maven too.