### PR TITLE
Fix #53: use a -jdk- base image rather than -jre-

### DIFF
--- a/jdk-8-alpine/Dockerfile
+++ b/jdk-8-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # DO NOT UPGRADE alpine until https://bugs.alpinelinux.org/issues/7372 is fixed
-FROM openjdk:8u121-jre-alpine
+FROM openjdk:8u121-jdk-alpine
 
 RUN apk add --no-cache curl tar bash
 


### PR DESCRIPTION
This fixes a bug discussed in #53 and introduced in b7f10a80f, apparently a typo while fixing issue #46.  In this PR, the base image is set to `openjdk:8-jdk-alpine` instead of `openjdk:8-jre-alpine`, as the latter does not include `javac`, needed to build java code.  

I have tested this fix with a container that builds a java library using maven.  Without the fix, the build fails with the error message shown in #53; with the fix, it completes successfully.  
