### PR TITLE
bump broken version

### DIFF
--- a/jdk-8/Dockerfile
+++ b/jdk-8/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-jdk-alpine
 
 RUN apk add --no-cache curl tar bash
 
-ARG MAVEN_VERSION=3.5.0
+ARG MAVEN_VERSION=3.5.2
 ARG USER_HOME_DIR="/root"
 ARG SHA=beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries


### PR DESCRIPTION
there is no longer a maven version 3.5.0 in the corresponding repository.
https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries

i bumped to 3.5.2

all the best
Benjamin