### PR TITLE
Add jdk-11 and jdk-11-slim images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ docker-maven
 * [jdk-9-slim](https://github.com/carlossg/docker-maven/blob/master/jdk-9-slim/Dockerfile)
 * [jdk-10](https://github.com/carlossg/docker-maven/blob/master/jdk-10/Dockerfile)
 * [jdk-10-slim](https://github.com/carlossg/docker-maven/blob/master/jdk-10-slim/Dockerfile)
+* [jdk-11](https://github.com/carlossg/docker-maven/blob/master/jdk-11/Dockerfile)
+* [jdk-11-slim](https://github.com/carlossg/docker-maven/blob/master/jdk-11-slim/Dockerfile)
 * [ibmjava-8](https://github.com/carlossg/docker-maven/blob/master/ibmjava-8/Dockerfile)
 * [ibmjava-8-alpine](https://github.com/carlossg/docker-maven/blob/alpine/ibmjava-8/Dockerfile)
 * [ibmjava-9](https://github.com/carlossg/docker-maven/blob/master/ibmjava-9/Dockerfile)

--- a/jdk-11-slim/Dockerfile
+++ b/jdk-11-slim/Dockerfile
@@ -1,0 +1,32 @@
+FROM openjdk:11-jdk-slim
+
+ARG MAVEN_VERSION=3.5.3
+ARG USER_HOME_DIR="/root"
+ARG SHA=b52956373fab1dd4277926507ab189fb797b3bc51a2a267a193c931fffad8408
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN apt-get update && \
+    apt-get install -y \
+      curl procps \
+  && rm -rf /var/lib/apt/lists/*
+
+# Maven fails with 'Can't read cryptographic policy directory: unlimited'
+# because it looks for $JAVA_HOME/conf/security/policy/unlimited but it is in
+# /etc/java-9-openjdk/security/policy/unlimited
+RUN ln -s /etc/java-11-openjdk /usr/lib/jvm/java-11-openjdk-$(dpkg --print-architecture)/conf
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY settings-docker.xml /usr/share/maven/ref/
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/jdk-11-slim/mvn-entrypoint.sh
+++ b/jdk-11-slim/mvn-entrypoint.sh
@@ -1,0 +1,39 @@
+#! /bin/bash -eu
+
+set -o pipefail
+
+# Copy files from /usr/share/maven/ref into ${MAVEN_CONFIG}
+# So the initial ~/.m2 is set with expected content.
+# Don't override, as this is just a reference setup
+copy_reference_file() {
+  local root="${1}"
+  local f="${2%/}"
+  local logfile="${3}"
+  local rel="${f/${root}/}" # path relative to /usr/share/maven/ref/
+  echo "$f" >> "$logfile"
+  echo " $f -> $rel" >> "$logfile"
+  if [[ ! -e ${MAVEN_CONFIG}/${rel} || $f = *.override ]]
+  then
+    echo "copy $rel to ${MAVEN_CONFIG}" >> "$logfile"
+    mkdir -p "${MAVEN_CONFIG}/$(dirname "${rel}")"
+    cp -r "${f}" "${MAVEN_CONFIG}/${rel}";
+  fi;
+}
+
+copy_reference_files() {
+  local log="$MAVEN_CONFIG/copy_reference_file.log"
+
+  if (sh -c "mkdir -p \"$MAVEN_CONFIG\" && touch \"${log}\"" > /dev/null 2>&1)
+  then
+      echo "--- Copying files at $(date)" >> "$log"
+      find /usr/share/maven/ref/ -type f -exec bash -eu -c 'copy_reference_file /usr/share/maven/ref/ "$1" "$2"' _ {} "$log" \;
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
+}
+
+export -f copy_reference_file
+copy_reference_files
+unset MAVEN_CONFIG
+
+exec "$@"

--- a/jdk-11-slim/settings-docker.xml
+++ b/jdk-11-slim/settings-docker.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>

--- a/jdk-11/Dockerfile
+++ b/jdk-11/Dockerfile
@@ -1,0 +1,27 @@
+FROM openjdk:11-jdk
+
+ARG MAVEN_VERSION=3.5.3
+ARG USER_HOME_DIR="/root"
+ARG SHA=b52956373fab1dd4277926507ab189fb797b3bc51a2a267a193c931fffad8408
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+# Maven fails with 'Can't read cryptographic policy directory: unlimited'
+# because it looks for $JAVA_HOME/conf/security/policy/unlimited but it is in
+# /etc/java-9-openjdk/security/policy/unlimited
+RUN ln -s /etc/java-11-openjdk /usr/lib/jvm/java-11-openjdk-$(dpkg --print-architecture)/conf
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY settings-docker.xml /usr/share/maven/ref/
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/jdk-11/mvn-entrypoint.sh
+++ b/jdk-11/mvn-entrypoint.sh
@@ -1,0 +1,39 @@
+#! /bin/bash -eu
+
+set -o pipefail
+
+# Copy files from /usr/share/maven/ref into ${MAVEN_CONFIG}
+# So the initial ~/.m2 is set with expected content.
+# Don't override, as this is just a reference setup
+copy_reference_file() {
+  local root="${1}"
+  local f="${2%/}"
+  local logfile="${3}"
+  local rel="${f/${root}/}" # path relative to /usr/share/maven/ref/
+  echo "$f" >> "$logfile"
+  echo " $f -> $rel" >> "$logfile"
+  if [[ ! -e ${MAVEN_CONFIG}/${rel} || $f = *.override ]]
+  then
+    echo "copy $rel to ${MAVEN_CONFIG}" >> "$logfile"
+    mkdir -p "${MAVEN_CONFIG}/$(dirname "${rel}")"
+    cp -r "${f}" "${MAVEN_CONFIG}/${rel}";
+  fi;
+}
+
+copy_reference_files() {
+  local log="$MAVEN_CONFIG/copy_reference_file.log"
+
+  if (sh -c "mkdir -p \"$MAVEN_CONFIG\" && touch \"${log}\"" > /dev/null 2>&1)
+  then
+      echo "--- Copying files at $(date)" >> "$log"
+      find /usr/share/maven/ref/ -type f -exec bash -eu -c 'copy_reference_file /usr/share/maven/ref/ "$1" "$2"' _ {} "$log" \;
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
+}
+
+export -f copy_reference_file
+copy_reference_files
+unset MAVEN_CONFIG
+
+exec "$@"

--- a/jdk-11/settings-docker.xml
+++ b/jdk-11/settings-docker.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>


### PR DESCRIPTION
Based on PR #66 and fixes #79.

This needs to wait for https://github.com/docker-library/openjdk/pull/186 since it requires openjdk 11 docker images.