### PR TITLE
Maven 3.6.0 on azul j11

### DIFF
--- a/azulzulu-11/Dockerfile
+++ b/azulzulu-11/Dockerfile
@@ -1,0 +1,26 @@
+FROM azul/zulu-openjdk:11.0.1-11.2
+
+ARG MAVEN_VERSION=3.6.0
+ARG USER_HOME_DIR="/root"
+ARG SHA=fae9c12b570c3ba18116a4e26ea524b29f7279c17cbaadc3326ca72927368924d9131d11b9e851b8dc9162228b6fdea955446be41207a5cfc61283dd8a561d2f
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN apt-get -qq update \
+    && apt-get -qqy install curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY settings-docker.xml /usr/share/maven/ref/
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/azulzulu-11/Dockerfile
+++ b/azulzulu-11/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:11.0.1-11.2
+FROM azul/zulu-openjdk:11
 
 ARG MAVEN_VERSION=3.6.0
 ARG USER_HOME_DIR="/root"

--- a/azulzulu-11/mvn-entrypoint.sh
+++ b/azulzulu-11/mvn-entrypoint.sh
@@ -1,0 +1,39 @@
+#! /bin/bash -eu
+
+set -o pipefail
+
+# Copy files from /usr/share/maven/ref into ${MAVEN_CONFIG}
+# So the initial ~/.m2 is set with expected content.
+# Don't override, as this is just a reference setup
+copy_reference_file() {
+  local root="${1}"
+  local f="${2%/}"
+  local logfile="${3}"
+  local rel="${f/${root}/}" # path relative to /usr/share/maven/ref/
+  echo "$f" >> "$logfile"
+  echo " $f -> $rel" >> "$logfile"
+  if [[ ! -e ${MAVEN_CONFIG}/${rel} || $f = *.override ]]
+  then
+    echo "copy $rel to ${MAVEN_CONFIG}" >> "$logfile"
+    mkdir -p "${MAVEN_CONFIG}/$(dirname "${rel}")"
+    cp -r "${f}" "${MAVEN_CONFIG}/${rel}";
+  fi;
+}
+
+copy_reference_files() {
+  local log="$MAVEN_CONFIG/copy_reference_file.log"
+
+  if (sh -c "mkdir -p \"$MAVEN_CONFIG\" && touch \"${log}\"" > /dev/null 2>&1)
+  then
+      echo "--- Copying files at $(date)" >> "$log"
+      find /usr/share/maven/ref/ -type f -exec bash -eu -c 'copy_reference_file /usr/share/maven/ref/ "$1" "$2"' _ {} "$log" \;
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
+}
+
+export -f copy_reference_file
+copy_reference_files
+unset MAVEN_CONFIG
+
+exec "$@"

--- a/azulzulu-11/settings-docker.xml
+++ b/azulzulu-11/settings-docker.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>


### PR DESCRIPTION
This is maven 3.6.0 on another java-11 variant. I cribbed from the jdk-11 base image to get started. There aren't many changes to speak of...

1. Dockerfile has minor changes to keep up with the ubuntu base image.
2. mvn-entrypoint.sh and settings-docker.xml are unchanged from their jdk-11/ versions.

I ran tests this way, which seemed to pass.

TAG=jdk-11 bats tests
