### PR TITLE
Update windows maven to 3.6.3 and upgrade some JDK's

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           $windowsReleaseId = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name ReleaseID | Select-Object ReleaseID).ReleaseID
 
           if($dockerfile.Name.Contains('nanoserver')) {
-            $windowsType = 'windowsnanoserver'
+            $windowsType = ''
             $windowsDockerTag = $windowsReleaseId
           }
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           Push-Location
           $dockerfile = $_
 
-          $windowsType = 'windowsservercore'
+          $windowsType = '-windowsservercore'
           $windowsDockerTag = 'ltsc2019'
           $windowsReleaseId = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name ReleaseID | Select-Object ReleaseID).ReleaseID
 
@@ -40,7 +40,7 @@ jobs:
 
           $tags | ForEach-Object {
             Push-Location windows
-            $tag = ('${{ secrets.DOCKER_USERNAME }}/maven:{0}-{1}-{2}-{3}' -f $_,$dockerfile.Name.Replace('Dockerfile.windows-', ''),$windowsType,$windowsDockerTag)
+            $tag = ('csanchez/maven:{0}-{1}{2}-{3}' -f $_,$dockerfile.Name.Replace('Dockerfile.windows-', ''),$windowsType,$windowsDockerTag)
             docker build -f $dockerfile --tag $tag --build-arg WINDOWS_DOCKER_TAG=${windowsDockerTag} .
 
             if('${{ github.event_name }}' -eq 'push') {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ docker-maven
 
 # Supported tags and respective Dockerfile links
 
-See [Docker Hub](https://hub.docker.com/_/maven) for updated list of tags
+## Linux Based Images
+
+See [Docker Hub](https://hub.docker.com/_/maven) for an updated list of tags
 
 * [jdk-8](https://github.com/carlossg/docker-maven/blob/master/jdk-8/Dockerfile)
 * [jdk-8-openj9](https://github.com/carlossg/docker-maven/blob/master/jdk-8-openj9/Dockerfile)
@@ -23,6 +25,23 @@ See [Docker Hub](https://hub.docker.com/_/maven) for updated list of tags
 * [amazoncorretto-11-windows](https://github.com/carlossg/docker-maven/blob/master/amazoncorretto-11/Dockerfile.windows)
 * [azulzulu-11](https://github.com/carlossg/docker-maven/blob/master/azulzulu-11/Dockerfile)
 * [azulzulu-11-windows](https://github.com/carlossg/docker-maven/blob/master/azulzulu-11/Dockerfile.windows)
+
+## Windows Based Images
+
+See [Docker Hub](https://hub.docker.com/r/csanchez/maven) for an updated list of tags
+
+* [jdk-8-openj9-windows](https://github.com/carlossg/docker-maven/blob/master/windows/Dockerfile.windows-jdk-8-openj9)
+* [jdk-8-windows](https://github.com/carlossg/docker-maven/blob/master/windows/Dockerfile.windows-jdk-8)
+* [jdk-8-windows-nanoserver](https://github.com/carlossg/docker-maven/blob/master/windows/Dockerfile.windows-jdk-8-nanoserver)
+* [jdk-11-openj9-windows](https://github.com/carlossg/docker-maven/blob/master/windows/Dockerfile.windows-jdk-11-openj9)
+* [jdk-11-windows](https://github.com/carlossg/docker-maven/blob/master/windows/Dockerfile.windows-jdk-11)
+* [jdk-11-windows-nanoserver](https://github.com/carlossg/docker-maven/blob/master/windows/Dockerfile.windows-jdk-11-nanoserver)
+* [jdk-13-windows](https://github.com/carlossg/docker-maven/blob/master/windows/Dockerfile.windows-jdk-13)
+* [jdk-14-windows](https://github.com/carlossg/docker-maven/blob/master/windows/Dockerfile.windows-jdk-14)
+* [amazoncorretto-8-windows](https://github.com/carlossg/docker-maven/blob/master/windows/Dockerfile.windows-amazoncorretto-8)
+* [amazoncorretto-11-windows](https://github.com/carlossg/docker-maven/blob/master/windows/Dockerfile.windows-amazoncorretto-11)
+* [azulzulu-11-windows](https://github.com/carlossg/docker-maven/blob/master/windows/Dockerfile.windows-azulzulu-11)
+
 
 # What is Maven?
 
@@ -45,6 +64,12 @@ passing a Maven command to `docker run`:
 
 ```powershell
 docker run -it --rm --name my-maven-project -v "$(Get-Location)":C:/Src -w C:/Src csanchez/maven:3.3-jdk-8-windows mvn verify
+```
+
+### Windows
+
+```powershell
+docker run -it --rm --name my-maven-project -v "$(Get-Location)":C:/Src -w C:/Src maven:3.3-jdk-8-windows mvn clean install
 ```
 
 ## Building local Docker image (optional)
@@ -154,6 +179,11 @@ or run all the tests with
 
 ### Linux
     for dir in $(/bin/ls -1 -d */ | grep -v 'tests\|windows'); do TAG=$(basename $dir) bats tests; done
+
+### Windows
+```powershell
+Get-ChildItem -Path windows\* -File -Include "Dockerfile.windows-*" | ForEach-Object { Push-Location ; $env:TAG=$_.Name.Replace('Dockerfile.windows-', '') ; Invoke-Pester -Path tests ; Pop-Location }
+```
 
 ### Windows
 ```powershell

--- a/windows/Dockerfile.windows-amazoncorretto-11
+++ b/windows/Dockerfile.windows-amazoncorretto-11
@@ -4,20 +4,20 @@ FROM mcr.microsoft.com/windows/servercore:$WINDOWS_DOCKER_TAG
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG zip=amazon-corretto-11.0.5.10.1-windows-x64.zip
-ARG uri=https://d3pxv6yz143wms.cloudfront.net/11.0.5.10.1/
-ARG hash=741d0fcee20754e17dd230d7eaf5dff3
+ARG zip=amazon-corretto-11-x64-windows-jdk.zip
+ARG uri=https://corretto.aws/downloads/latest/
+ARG hash=9d590d3e1d4fe8b927f0b8498f992d53
 
 RUN Invoke-WebRequest -Uri $('{0}{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zip ; `
     if((Get-FileHash C:/$env:zip -Algorithm MD5).Hash.ToLower() -ne $env:hash) { exit 1 } ; `
     Expand-Archive -Path C:/$env:zip -Destination C:/ProgramData ; `
     Remove-Item C:/${env:zip}
 
-ENV JAVA_HOME=C:/ProgramData/jdk11.0.5_10
+ENV JAVA_HOME=C:/ProgramData/jdk11.0.6_10
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.6.3
-ARG SHA=4bb0e0bb1fb74f1b990ba9a6493cc6345873d9188fc7613df16ab0d5bd2017de5a3917af4502792f0bad1fcc95785dcc6660f7add53548e0ec4bfb30ce4b1da7
+ARG SHA=1c095ed556eda06c6d82fdf52200bc4f3437a1bab42387e801d6f4c56e833fb82b16e8bf0aab95c9708de7bfb55ec27f653a7cf0f491acebc541af234eded94d
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/windows/Dockerfile.windows-amazoncorretto-8
+++ b/windows/Dockerfile.windows-amazoncorretto-8
@@ -4,20 +4,20 @@ FROM mcr.microsoft.com/windows/servercore:$WINDOWS_DOCKER_TAG
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG zip=amazon-corretto-8.232.09.1-windows-x64-jdk.zip
-ARG uri=https://d3pxv6yz143wms.cloudfront.net/8.232.09.1/
-ARG hash=b0d375cbcfcda6d04e87888c6c6763d3
+ARG zip=amazon-corretto-8-x64-windows-jdk.zip
+ARG uri=https://corretto.aws/downloads/latest/
+ARG hash=4e33650b437008622771c8947f145bc5
 
 RUN Invoke-WebRequest -Uri $('{0}{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zip ; `
     if((Get-FileHash C:/$env:zip -Algorithm MD5).Hash.ToLower() -ne $env:hash) { exit 1 } ; `
     Expand-Archive -Path C:/$env:zip -Destination C:/ProgramData ; `
     Remove-Item C:/${env:zip}
 
-ENV JAVA_HOME=C:/ProgramData/jdk1.8.0_232
+ENV JAVA_HOME=C:/ProgramData/jdk1.8.0_242
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.6.3
-ARG SHA=4bb0e0bb1fb74f1b990ba9a6493cc6345873d9188fc7613df16ab0d5bd2017de5a3917af4502792f0bad1fcc95785dcc6660f7add53548e0ec4bfb30ce4b1da7
+ARG SHA=1c095ed556eda06c6d82fdf52200bc4f3437a1bab42387e801d6f4c56e833fb82b16e8bf0aab95c9708de7bfb55ec27f653a7cf0f491acebc541af234eded94d
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/windows/Dockerfile.windows-azulzulu-11
+++ b/windows/Dockerfile.windows-azulzulu-11
@@ -4,20 +4,20 @@ FROM mcr.microsoft.com/windows/servercore:$WINDOWS_DOCKER_TAG
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG zip=/zulu11.35.13-ca-jdk11.0.5-win_x64.zip
+ARG zip=/zulu11.37.17-ca-jdk11.0.6-win_x64.zip
 ARG uri=https://cdn.azul.com/zulu/bin/
-ARG hash=ac2d5f8a1e60b2dcb35323c8039ab117b539514f5610fe3602da65f74bad16b8
+ARG hash=a9695617b8374bfa171f166951214965b1d1d08f43218db9a2a780b71c665c18
 
 RUN Invoke-WebRequest -Uri $('{0}{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zip ; `
     if((Get-FileHash C:/$env:zip -Algorithm SHA256).Hash.ToLower() -ne $env:hash) { exit 1 } ; `
     Expand-Archive -Path C:/$env:zip -Destination C:/ProgramData ; `
     Remove-Item C:/${env:zip}
 
-ENV JAVA_HOME=C:/ProgramData/zulu11.35.13-ca-jdk11.0.5-win_x64
+ENV JAVA_HOME=C:/ProgramData/zulu11.37.17-ca-jdk11.0.6-win_x64
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.6.3
-ARG SHA=4bb0e0bb1fb74f1b990ba9a6493cc6345873d9188fc7613df16ab0d5bd2017de5a3917af4502792f0bad1fcc95785dcc6660f7add53548e0ec4bfb30ce4b1da7
+ARG SHA=1c095ed556eda06c6d82fdf52200bc4f3437a1bab42387e801d6f4c56e833fb82b16e8bf0aab95c9708de7bfb55ec27f653a7cf0f491acebc541af234eded94d
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `
@@ -30,7 +30,7 @@ RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin
 ENV MAVEN_HOME C:/ProgramData/Maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
-ENV JAVA_HOME=C:/ProgramData/zulu11.35.13-ca-jdk11.0.5-win_x64
+ENV JAVA_HOME=C:/ProgramData/zulu11.37.17-ca-jdk11.0.6-win_x64
 
 COPY mvn-entrypoint.ps1 C:/ProgramData/Maven/mvn-entrypoint.ps1
 COPY settings-docker.xml C:/ProgramData/Maven/Reference/settings-docker.xml

--- a/windows/Dockerfile.windows-jdk-11
+++ b/windows/Dockerfile.windows-jdk-11
@@ -6,7 +6,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.6.3
-ARG SHA=4bb0e0bb1fb74f1b990ba9a6493cc6345873d9188fc7613df16ab0d5bd2017de5a3917af4502792f0bad1fcc95785dcc6660f7add53548e0ec4bfb30ce4b1da7
+ARG SHA=1c095ed556eda06c6d82fdf52200bc4f3437a1bab42387e801d6f4c56e833fb82b16e8bf0aab95c9708de7bfb55ec27f653a7cf0f491acebc541af234eded94d
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/windows/Dockerfile.windows-jdk-11-nanoserver
+++ b/windows/Dockerfile.windows-jdk-11-nanoserver
@@ -1,6 +1,6 @@
 # escape=`
 ARG WINDOWS_DOCKER_TAG=1809
-ARG JAVA_VERSION=11.0.5
+ARG JAVA_VERSION=11.0.6
 # we use the latest stable if nothing is passed
 ARG POWERSHELL_VERSION=
 
@@ -21,7 +21,7 @@ ENV WindowsPATH="C:\Windows\system32;C:\Windows"
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.6.3
-ARG SHA=4bb0e0bb1fb74f1b990ba9a6493cc6345873d9188fc7613df16ab0d5bd2017de5a3917af4502792f0bad1fcc95785dcc6660f7add53548e0ec4bfb30ce4b1da7
+ARG SHA=1c095ed556eda06c6d82fdf52200bc4f3437a1bab42387e801d6f4c56e833fb82b16e8bf0aab95c9708de7bfb55ec27f653a7cf0f491acebc541af234eded94d
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/windows/Dockerfile.windows-jdk-11-openj9
+++ b/windows/Dockerfile.windows-jdk-11-openj9
@@ -1,6 +1,6 @@
 # escape=`
 ARG WINDOWS_DOCKER_TAG=1809
-FROM openjdk:8-jdk-windowsservercore-$WINDOWS_DOCKER_TAG
+FROM adoptopenjdk:11-openj9-windowsservercore-$WINDOWS_DOCKER_TAG
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/windows/Dockerfile.windows-jdk-13
+++ b/windows/Dockerfile.windows-jdk-13
@@ -6,7 +6,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.6.3
-ARG SHA=4bb0e0bb1fb74f1b990ba9a6493cc6345873d9188fc7613df16ab0d5bd2017de5a3917af4502792f0bad1fcc95785dcc6660f7add53548e0ec4bfb30ce4b1da7
+ARG SHA=1c095ed556eda06c6d82fdf52200bc4f3437a1bab42387e801d6f4c56e833fb82b16e8bf0aab95c9708de7bfb55ec27f653a7cf0f491acebc541af234eded94d
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/windows/Dockerfile.windows-jdk-14
+++ b/windows/Dockerfile.windows-jdk-14
@@ -6,7 +6,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.6.3
-ARG SHA=4bb0e0bb1fb74f1b990ba9a6493cc6345873d9188fc7613df16ab0d5bd2017de5a3917af4502792f0bad1fcc95785dcc6660f7add53548e0ec4bfb30ce4b1da7
+ARG SHA=1c095ed556eda06c6d82fdf52200bc4f3437a1bab42387e801d6f4c56e833fb82b16e8bf0aab95c9708de7bfb55ec27f653a7cf0f491acebc541af234eded94d
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/windows/Dockerfile.windows-jdk-8-nanoserver
+++ b/windows/Dockerfile.windows-jdk-8-nanoserver
@@ -1,6 +1,6 @@
 # escape=`
 ARG WINDOWS_DOCKER_TAG=1809
-ARG JAVA_VERSION=8u232
+ARG JAVA_VERSION=8u242
 # we use the latest stable if nothing is passed
 ARG POWERSHELL_VERSION=
 
@@ -21,7 +21,7 @@ ENV WindowsPATH="C:\Windows\system32;C:\Windows"
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.6.3
-ARG SHA=4bb0e0bb1fb74f1b990ba9a6493cc6345873d9188fc7613df16ab0d5bd2017de5a3917af4502792f0bad1fcc95785dcc6660f7add53548e0ec4bfb30ce4b1da7
+ARG SHA=1c095ed556eda06c6d82fdf52200bc4f3437a1bab42387e801d6f4c56e833fb82b16e8bf0aab95c9708de7bfb55ec27f653a7cf0f491acebc541af234eded94d
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/windows/Dockerfile.windows-jdk-8-openj9
+++ b/windows/Dockerfile.windows-jdk-8-openj9
@@ -1,6 +1,6 @@
 # escape=`
 ARG WINDOWS_DOCKER_TAG=1809
-FROM openjdk:8-jdk-windowsservercore-$WINDOWS_DOCKER_TAG
+FROM adoptopenjdk:8-openj9-windowsservercore-$WINDOWS_DOCKER_TAG
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 


### PR DESCRIPTION
 Some of the JDKs have issues with nanoserver, so
 I updated them to versions that should work with
 nanoserver.

 Updated the README to have the correct
 paths to the Dockerfiles for Windows.

 Added openj9 versions for jdk8 and jdk11. Currently
 there are some issues with openj9 for nanoserver, so
 I did not add those variants.