### PR TITLE
Adds openjdk:14-slim tag

### DIFF
--- a/openjdk-14-slim/Dockerfile
+++ b/openjdk-14-slim/Dockerfile
@@ -1,0 +1,27 @@
+FROM openjdk:14-jdk-slim
+
+ARG MAVEN_VERSION=3.6.3
+ARG USER_HOME_DIR="/root"
+ARG SHA=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN apt-get update && \
+  apt-get install -y \
+  curl procps \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY settings-docker.xml /usr/share/maven/ref/
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/openjdk-14-slim/mvn-entrypoint.sh
+++ b/openjdk-14-slim/mvn-entrypoint.sh
@@ -1,0 +1,50 @@
+#! /bin/sh -eu
+
+# Copy files from /usr/share/maven/ref into ${MAVEN_CONFIG}
+# So the initial ~/.m2 is set with expected content.
+# Don't override, as this is just a reference setup
+
+copy_reference_files() {
+  local log="$MAVEN_CONFIG/copy_reference_file.log"
+  local ref="/usr/share/maven/ref"
+
+  if mkdir -p "${MAVEN_CONFIG}/repository" && touch "${log}" > /dev/null 2>&1 ; then
+      cd "${ref}"
+      local reflink=""
+      if cp --help 2>&1 | grep -q reflink ; then
+          reflink="--reflink=auto"
+      fi
+      if [ -n "$(find "${MAVEN_CONFIG}/repository" -maxdepth 0 -type d -empty 2>/dev/null)" ] ; then
+          # destination is empty...
+          echo "--- Copying all files to ${MAVEN_CONFIG} at $(date)" >> "${log}"
+          cp -rv ${reflink} . "${MAVEN_CONFIG}" >> "${log}"
+      else
+          # destination is non-empty, copy file-by-file
+          echo "--- Copying individual files to ${MAVEN_CONFIG} at $(date)" >> "${log}"
+          find . -type f -exec sh -eu -c '
+              log="${1}"
+              shift
+              reflink="${1}"
+              shift
+              for f in "$@" ; do
+                  if [ ! -e "${MAVEN_CONFIG}/${f}" ] || [ -e "${f}.override" ] ; then
+                      mkdir -p "${MAVEN_CONFIG}/$(dirname "${f}")"
+                      cp -rv ${reflink} "${f}" "${MAVEN_CONFIG}/${f}" >> "${log}"
+                  fi
+              done
+          ' _ "${log}" "${reflink}" {} +
+      fi
+      echo >> "${log}"
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
+}
+
+owd="$(pwd)"
+copy_reference_files
+unset MAVEN_CONFIG
+
+cd "${owd}"
+unset owd
+
+exec "$@"

--- a/openjdk-14-slim/settings-docker.xml
+++ b/openjdk-14-slim/settings-docker.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>


### PR DESCRIPTION
I notice that there are no slim version to openjdk 14 so I thought i could help.

- I created a folder for the slim version following the naming convention
- I repeated the same structure for the openjdk14 folder
- I changed the base image to openjdk:14-slim
- Added a RUN statement to install curl and procps

Is there anything missing?
