### PR TITLE
feat: lock images to oraclelinux8

### DIFF
--- a/openjdk-14/Dockerfile
+++ b/openjdk-14/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:14-jdk
+FROM openjdk:14-jdk-oraclelinux8
 
 ARG MAVEN_VERSION=3.6.3
 ARG USER_HOME_DIR="/root"

--- a/openjdk-15/Dockerfile
+++ b/openjdk-15/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:15-jdk
+FROM openjdk:15-jdk-oraclelinux8
 
 ARG MAVEN_VERSION=3.6.3
 ARG USER_HOME_DIR="/root"

--- a/openjdk-16/Dockerfile
+++ b/openjdk-16/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16-jdk
+FROM openjdk:16-jdk-oraclelinux8
 
 ARG MAVEN_VERSION=3.6.3
 ARG USER_HOME_DIR="/root"


### PR DESCRIPTION
although nothing changes as they were already switched to by openjdk:1?-jdk