### PR TITLE
Add --network host flag to linux command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ passing a Maven command to `docker run`:
 
 ### Linux
 
-    docker run -it --rm --name my-maven-project -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven maven:3.3-jdk-8 mvn verify
+    docker run -it --rm --networking host --name my-maven-project -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven maven:3.3-jdk-8 mvn verify
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ passing a Maven command to `docker run`:
 
 ### Linux
 
-    docker run -it --rm --networking host --name my-maven-project -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven maven:3.3-jdk-8 mvn verify
+    docker run -it --rm --network host --name my-maven-project -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven maven:3.3-jdk-8 mvn verify
 
 ### Windows
 


### PR DESCRIPTION
Hey, I ran into the issue of networking trying to run this locally as docker by default disallows ipv4 forwarding, thought it might be helpful to show the network flag which enables ipv4 forwarding for the host