### PR TITLE
Liberica 17

### DIFF
--- a/.github/workflows/libericaopenjdk-17-alpine.yml
+++ b/.github/workflows/libericaopenjdk-17-alpine.yml
@@ -1,120 +1,22 @@
-name: DIRECTORY
+name: libericaopenjdk-17-alpine
 
 on:
   push:
     paths:
-      - '!LICENSE/**'
-      - '!README-short.txt/**'
-      - '!README.md/**'
-      - '!amazoncorretto-11/**'
-      - '!amazoncorretto-11-windowsservercore/**'
-      - '!amazoncorretto-17/**'
-      - '!amazoncorretto-8/**'
-      - '!amazoncorretto-8-windowsservercore/**'
-      - '!azulzulu-11/**'
-      - '!azulzulu-11-alpine/**'
-      - '!azulzulu-11-windowsservercore/**'
-      - '!azulzulu-17/**'
-      - '!azulzulu-17-alpine/**'
-      - '!common.sh/**'
-      - '!eclipse-temurin-11/**'
-      - '!eclipse-temurin-11-alpine/**'
-      - '!eclipse-temurin-17/**'
-      - '!eclipse-temurin-17-alpine/**'
-      - '!eclipse-temurin-18/**'
-      - '!eclipse-temurin-18-alpine/**'
-      - '!eclipse-temurin-8/**'
-      - '!eclipse-temurin-8-alpine/**'
-      - '!generate-stackbrew-library.sh/**'
-      - '!github-action-generation.sh/**'
-      - '!github-action.ps1/**'
-      - '!ibm-semeru-11-focal/**'
-      - '!ibm-semeru-17-focal/**'
-      - '!ibmjava-8/**'
-      - '!ibmjava-8-alpine/**'
-      - '!libericaopenjdk-11/**'
-      - '!libericaopenjdk-11-alpine/**'
-      - '!libericaopenjdk-17/**'
-      - '!libericaopenjdk-17-alpine/**'
-      - '!libericaopenjdk-8/**'
-      - '!libericaopenjdk-8-alpine/**'
-      - '!logo.png/**'
-      - '!microsoft-openjdk-11-ubuntu/**'
-      - '!microsoft-openjdk-16-ubuntu/**'
-      - '!microsoft-openjdk-17-ubuntu/**'
-      - '!openjdk-11/**'
-      - '!openjdk-11-nanoserver/**'
-      - '!openjdk-11-slim/**'
-      - '!openjdk-11-windowsservercore/**'
-      - '!openjdk-18/**'
-      - '!openjdk-18-slim/**'
-      - '!openjdk-8/**'
-      - '!openjdk-8-nanoserver/**'
-      - '!openjdk-8-slim/**'
-      - '!openjdk-8-windowsservercore/**'
-      - '!publish.sh/**'
-      - '!sapmachine-11/**'
-      - '!sapmachine-17/**'
-      - '!tags-for-dir.sh/**'
-      - '!tests/**'
+      - "libericaopenjdk-17-alpine/**"
+      - .github/workflows/libericaopenjdk-17-alpine.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
       - "!tests/*.ps*"
       - "!tests/*.windows"
   pull_request:
     paths:
-      - '!LICENSE/**'
-      - '!README-short.txt/**'
-      - '!README.md/**'
-      - '!amazoncorretto-11/**'
-      - '!amazoncorretto-11-windowsservercore/**'
-      - '!amazoncorretto-17/**'
-      - '!amazoncorretto-8/**'
-      - '!amazoncorretto-8-windowsservercore/**'
-      - '!azulzulu-11/**'
-      - '!azulzulu-11-alpine/**'
-      - '!azulzulu-11-windowsservercore/**'
-      - '!azulzulu-17/**'
-      - '!azulzulu-17-alpine/**'
-      - '!common.sh/**'
-      - '!eclipse-temurin-11/**'
-      - '!eclipse-temurin-11-alpine/**'
-      - '!eclipse-temurin-17/**'
-      - '!eclipse-temurin-17-alpine/**'
-      - '!eclipse-temurin-18/**'
-      - '!eclipse-temurin-18-alpine/**'
-      - '!eclipse-temurin-8/**'
-      - '!eclipse-temurin-8-alpine/**'
-      - '!generate-stackbrew-library.sh/**'
-      - '!github-action-generation.sh/**'
-      - '!github-action.ps1/**'
-      - '!ibm-semeru-11-focal/**'
-      - '!ibm-semeru-17-focal/**'
-      - '!ibmjava-8/**'
-      - '!ibmjava-8-alpine/**'
-      - '!libericaopenjdk-11/**'
-      - '!libericaopenjdk-11-alpine/**'
-      - '!libericaopenjdk-17/**'
-      - '!libericaopenjdk-17-alpine/**'
-      - '!libericaopenjdk-8/**'
-      - '!libericaopenjdk-8-alpine/**'
-      - '!logo.png/**'
-      - '!microsoft-openjdk-11-ubuntu/**'
-      - '!microsoft-openjdk-16-ubuntu/**'
-      - '!microsoft-openjdk-17-ubuntu/**'
-      - '!openjdk-11/**'
-      - '!openjdk-11-nanoserver/**'
-      - '!openjdk-11-slim/**'
-      - '!openjdk-11-windowsservercore/**'
-      - '!openjdk-18/**'
-      - '!openjdk-18-slim/**'
-      - '!openjdk-8/**'
-      - '!openjdk-8-nanoserver/**'
-      - '!openjdk-8-slim/**'
-      - '!openjdk-8-windowsservercore/**'
-      - '!publish.sh/**'
-      - '!sapmachine-11/**'
-      - '!sapmachine-17/**'
-      - '!tags-for-dir.sh/**'
-      - '!tests/**'
+      - "libericaopenjdk-17-alpine/**"
+      - .github/workflows/libericaopenjdk-17-alpine.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
       - "!tests/*.ps*"
       - "!tests/*.windows"
 
@@ -162,7 +64,7 @@ jobs:
       - name: Test
         run: bats tests
         env:
-          TAG: DIRECTORY
+          TAG: libericaopenjdk-17-alpine
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -188,9 +90,9 @@ jobs:
         uses: docker/metadata-action@v3.6.0
         with:
           tags: |
-            type=schedule,suffix=-DIRECTORY
-            type=ref,event=tag,suffix=-DIRECTORY
-            type=ref,event=pr,prefix=pr-,suffix=-DIRECTORY
+            type=schedule,suffix=-libericaopenjdk-17-alpine
+            type=ref,event=tag,suffix=-libericaopenjdk-17-alpine
+            type=ref,event=pr,prefix=pr-,suffix=-libericaopenjdk-17-alpine
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             ${{ env.IMAGE_NAME2 }}
@@ -212,7 +114,7 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@v2
         with:
-          context: DIRECTORY
+          context: libericaopenjdk-17-alpine
           push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/libericaopenjdk-17.yml
+++ b/.github/workflows/libericaopenjdk-17.yml
@@ -1,120 +1,22 @@
-name: DIRECTORY
+name: libericaopenjdk-17
 
 on:
   push:
     paths:
-      - '!LICENSE/**'
-      - '!README-short.txt/**'
-      - '!README.md/**'
-      - '!amazoncorretto-11/**'
-      - '!amazoncorretto-11-windowsservercore/**'
-      - '!amazoncorretto-17/**'
-      - '!amazoncorretto-8/**'
-      - '!amazoncorretto-8-windowsservercore/**'
-      - '!azulzulu-11/**'
-      - '!azulzulu-11-alpine/**'
-      - '!azulzulu-11-windowsservercore/**'
-      - '!azulzulu-17/**'
-      - '!azulzulu-17-alpine/**'
-      - '!common.sh/**'
-      - '!eclipse-temurin-11/**'
-      - '!eclipse-temurin-11-alpine/**'
-      - '!eclipse-temurin-17/**'
-      - '!eclipse-temurin-17-alpine/**'
-      - '!eclipse-temurin-18/**'
-      - '!eclipse-temurin-18-alpine/**'
-      - '!eclipse-temurin-8/**'
-      - '!eclipse-temurin-8-alpine/**'
-      - '!generate-stackbrew-library.sh/**'
-      - '!github-action-generation.sh/**'
-      - '!github-action.ps1/**'
-      - '!ibm-semeru-11-focal/**'
-      - '!ibm-semeru-17-focal/**'
-      - '!ibmjava-8/**'
-      - '!ibmjava-8-alpine/**'
-      - '!libericaopenjdk-11/**'
-      - '!libericaopenjdk-11-alpine/**'
-      - '!libericaopenjdk-17/**'
-      - '!libericaopenjdk-17-alpine/**'
-      - '!libericaopenjdk-8/**'
-      - '!libericaopenjdk-8-alpine/**'
-      - '!logo.png/**'
-      - '!microsoft-openjdk-11-ubuntu/**'
-      - '!microsoft-openjdk-16-ubuntu/**'
-      - '!microsoft-openjdk-17-ubuntu/**'
-      - '!openjdk-11/**'
-      - '!openjdk-11-nanoserver/**'
-      - '!openjdk-11-slim/**'
-      - '!openjdk-11-windowsservercore/**'
-      - '!openjdk-18/**'
-      - '!openjdk-18-slim/**'
-      - '!openjdk-8/**'
-      - '!openjdk-8-nanoserver/**'
-      - '!openjdk-8-slim/**'
-      - '!openjdk-8-windowsservercore/**'
-      - '!publish.sh/**'
-      - '!sapmachine-11/**'
-      - '!sapmachine-17/**'
-      - '!tags-for-dir.sh/**'
-      - '!tests/**'
+      - "libericaopenjdk-17/**"
+      - .github/workflows/libericaopenjdk-17.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
       - "!tests/*.ps*"
       - "!tests/*.windows"
   pull_request:
     paths:
-      - '!LICENSE/**'
-      - '!README-short.txt/**'
-      - '!README.md/**'
-      - '!amazoncorretto-11/**'
-      - '!amazoncorretto-11-windowsservercore/**'
-      - '!amazoncorretto-17/**'
-      - '!amazoncorretto-8/**'
-      - '!amazoncorretto-8-windowsservercore/**'
-      - '!azulzulu-11/**'
-      - '!azulzulu-11-alpine/**'
-      - '!azulzulu-11-windowsservercore/**'
-      - '!azulzulu-17/**'
-      - '!azulzulu-17-alpine/**'
-      - '!common.sh/**'
-      - '!eclipse-temurin-11/**'
-      - '!eclipse-temurin-11-alpine/**'
-      - '!eclipse-temurin-17/**'
-      - '!eclipse-temurin-17-alpine/**'
-      - '!eclipse-temurin-18/**'
-      - '!eclipse-temurin-18-alpine/**'
-      - '!eclipse-temurin-8/**'
-      - '!eclipse-temurin-8-alpine/**'
-      - '!generate-stackbrew-library.sh/**'
-      - '!github-action-generation.sh/**'
-      - '!github-action.ps1/**'
-      - '!ibm-semeru-11-focal/**'
-      - '!ibm-semeru-17-focal/**'
-      - '!ibmjava-8/**'
-      - '!ibmjava-8-alpine/**'
-      - '!libericaopenjdk-11/**'
-      - '!libericaopenjdk-11-alpine/**'
-      - '!libericaopenjdk-17/**'
-      - '!libericaopenjdk-17-alpine/**'
-      - '!libericaopenjdk-8/**'
-      - '!libericaopenjdk-8-alpine/**'
-      - '!logo.png/**'
-      - '!microsoft-openjdk-11-ubuntu/**'
-      - '!microsoft-openjdk-16-ubuntu/**'
-      - '!microsoft-openjdk-17-ubuntu/**'
-      - '!openjdk-11/**'
-      - '!openjdk-11-nanoserver/**'
-      - '!openjdk-11-slim/**'
-      - '!openjdk-11-windowsservercore/**'
-      - '!openjdk-18/**'
-      - '!openjdk-18-slim/**'
-      - '!openjdk-8/**'
-      - '!openjdk-8-nanoserver/**'
-      - '!openjdk-8-slim/**'
-      - '!openjdk-8-windowsservercore/**'
-      - '!publish.sh/**'
-      - '!sapmachine-11/**'
-      - '!sapmachine-17/**'
-      - '!tags-for-dir.sh/**'
-      - '!tests/**'
+      - "libericaopenjdk-17/**"
+      - .github/workflows/libericaopenjdk-17.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
       - "!tests/*.ps*"
       - "!tests/*.windows"
 
@@ -162,7 +64,7 @@ jobs:
       - name: Test
         run: bats tests
         env:
-          TAG: DIRECTORY
+          TAG: libericaopenjdk-17
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -188,9 +90,9 @@ jobs:
         uses: docker/metadata-action@v3.6.0
         with:
           tags: |
-            type=schedule,suffix=-DIRECTORY
-            type=ref,event=tag,suffix=-DIRECTORY
-            type=ref,event=pr,prefix=pr-,suffix=-DIRECTORY
+            type=schedule,suffix=-libericaopenjdk-17
+            type=ref,event=tag,suffix=-libericaopenjdk-17
+            type=ref,event=pr,prefix=pr-,suffix=-libericaopenjdk-17
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             ${{ env.IMAGE_NAME2 }}
@@ -212,7 +114,7 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@v2
         with:
-          context: DIRECTORY
+          context: libericaopenjdk-17
           push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /tests/.settings/
 /tests/target/
 *.tmp
+.idea

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Only under `csanchez/maven` and `ghcr.io/carlossg/maven`:
 * [azulzulu-17-alpine](https://github.com/carlossg/docker-maven/blob/master/azulzulu-17-alpine/Dockerfile)
 * [libericaopenjdk-11](https://github.com/carlossg/docker-maven/blob/master/libericaopenjdk-11/Dockerfile)
 * [libericaopenjdk-11-alpine](https://github.com/carlossg/docker-maven/blob/master/libericaopenjdk-11-alpine/Dockerfile)
+* [libericaopenjdk-17](https://github.com/carlossg/docker-maven/blob/master/libericaopenjdk-17/Dockerfile)
+* [libericaopenjdk-17-alpine](https://github.com/carlossg/docker-maven/blob/master/libericaopenjdk-17-alpine/Dockerfile)
 * [libericaopenjdk-8](https://github.com/carlossg/docker-maven/blob/master/libericaopenjdk-8/Dockerfile)
 * [libericaopenjdk-8-alpine](https://github.com/carlossg/docker-maven/blob/master/libericaopenjdk-8-alpine/Dockerfile)
 * [microsoft-openjdk-11-ubuntu](https://github.com/carlossg/docker-maven/blob/master/microsoft-openjdk-11-ubuntu/Dockerfile)

--- a/common.sh
+++ b/common.sh
@@ -15,7 +15,7 @@ declare -A jdk_latest=(
 	["ibmjava"]="8"
 	["ibm-semeru"]=""
 	["amazoncorretto"]="11"
-	["libericaopenjdk"]="11"
+	["libericaopenjdk"]="17"
 	["sapmachine"]="17"
 )
 

--- a/github-action-generation.sh
+++ b/github-action-generation.sh
@@ -17,8 +17,10 @@ done
 
 # Create a workflow for everything else that may be added in a PR
 cp .github/github-action-template.yaml .github/workflows/other.yml
+# Preserve sort order
+LC_COLLATE=C
 for f in *; do
-    gsed -i "/DIRECTORY\/\*\*/i \      - '!${f}\/\*\*'" .github/workflows/other.yml
+    sed -i "/DIRECTORY\/\*\*/i \      - '!${f}\/\*\*'" .github/workflows/other.yml
 done
-gsed -i "s/Docker Maven Image CI DIRECTORY/Docker Maven Image CI other/" .github/workflows/other.yml
-gsed -i "/DIRECTORY\/\*\*/,+4 d" .github/workflows/other.yml
+sed -i "s/Docker Maven Image CI DIRECTORY/Docker Maven Image CI other/" .github/workflows/other.yml
+sed -i "/DIRECTORY\/\*\*/,+4 d" .github/workflows/other.yml

--- a/libericaopenjdk-17-alpine/Dockerfile
+++ b/libericaopenjdk-17-alpine/Dockerfile
@@ -1,0 +1,24 @@
+FROM bellsoft/liberica-openjdk-alpine:17
+
+RUN apk add --no-cache curl tar bash procps
+
+ARG MAVEN_VERSION=3.8.5
+ARG USER_HOME_DIR="/root"
+ARG SHA=89ab8ece99292476447ef6a6800d9842bbb60787b9b8a45c103aa61d2f205a971d8c3ddfb8b03e514455b4173602bd015e82958c0b3ddc1728a57126f773c743
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY settings-docker.xml /usr/share/maven/ref/
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/libericaopenjdk-17-alpine/mvn-entrypoint.sh
+++ b/libericaopenjdk-17-alpine/mvn-entrypoint.sh
@@ -1,0 +1,50 @@
+#! /bin/sh -eu
+
+# Copy files from /usr/share/maven/ref into ${MAVEN_CONFIG}
+# So the initial ~/.m2 is set with expected content.
+# Don't override, as this is just a reference setup
+
+copy_reference_files() {
+  local log="$MAVEN_CONFIG/copy_reference_file.log"
+  local ref="/usr/share/maven/ref"
+
+  if mkdir -p "${MAVEN_CONFIG}/repository" && touch "${log}" > /dev/null 2>&1 ; then
+      cd "${ref}"
+      local reflink=""
+      if cp --help 2>&1 | grep -q reflink ; then
+          reflink="--reflink=auto"
+      fi
+      if [ -n "$(find "${MAVEN_CONFIG}/repository" -maxdepth 0 -type d -empty 2>/dev/null)" ] ; then
+          # destination is empty...
+          echo "--- Copying all files to ${MAVEN_CONFIG} at $(date)" >> "${log}"
+          cp -rv ${reflink} . "${MAVEN_CONFIG}" >> "${log}"
+      else
+          # destination is non-empty, copy file-by-file
+          echo "--- Copying individual files to ${MAVEN_CONFIG} at $(date)" >> "${log}"
+          find . -type f -exec sh -eu -c '
+              log="${1}"
+              shift
+              reflink="${1}"
+              shift
+              for f in "$@" ; do
+                  if [ ! -e "${MAVEN_CONFIG}/${f}" ] || [ -e "${f}.override" ] ; then
+                      mkdir -p "${MAVEN_CONFIG}/$(dirname "${f}")"
+                      cp -rv ${reflink} "${f}" "${MAVEN_CONFIG}/${f}" >> "${log}"
+                  fi
+              done
+          ' _ "${log}" "${reflink}" {} +
+      fi
+      echo >> "${log}"
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
+}
+
+owd="$(pwd)"
+copy_reference_files
+unset MAVEN_CONFIG
+
+cd "${owd}"
+unset owd
+
+exec "$@"

--- a/libericaopenjdk-17-alpine/settings-docker.xml
+++ b/libericaopenjdk-17-alpine/settings-docker.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>

--- a/libericaopenjdk-17/Dockerfile
+++ b/libericaopenjdk-17/Dockerfile
@@ -1,0 +1,22 @@
+FROM bellsoft/liberica-openjdk-centos:17
+
+ARG MAVEN_VERSION=3.8.5
+ARG USER_HOME_DIR="/root"
+ARG SHA=89ab8ece99292476447ef6a6800d9842bbb60787b9b8a45c103aa61d2f205a971d8c3ddfb8b03e514455b4173602bd015e82958c0b3ddc1728a57126f773c743
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY settings-docker.xml /usr/share/maven/ref/
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/libericaopenjdk-17/mvn-entrypoint.sh
+++ b/libericaopenjdk-17/mvn-entrypoint.sh
@@ -1,0 +1,50 @@
+#! /bin/sh -eu
+
+# Copy files from /usr/share/maven/ref into ${MAVEN_CONFIG}
+# So the initial ~/.m2 is set with expected content.
+# Don't override, as this is just a reference setup
+
+copy_reference_files() {
+  local log="$MAVEN_CONFIG/copy_reference_file.log"
+  local ref="/usr/share/maven/ref"
+
+  if mkdir -p "${MAVEN_CONFIG}/repository" && touch "${log}" > /dev/null 2>&1 ; then
+      cd "${ref}"
+      local reflink=""
+      if cp --help 2>&1 | grep -q reflink ; then
+          reflink="--reflink=auto"
+      fi
+      if [ -n "$(find "${MAVEN_CONFIG}/repository" -maxdepth 0 -type d -empty 2>/dev/null)" ] ; then
+          # destination is empty...
+          echo "--- Copying all files to ${MAVEN_CONFIG} at $(date)" >> "${log}"
+          cp -rv ${reflink} . "${MAVEN_CONFIG}" >> "${log}"
+      else
+          # destination is non-empty, copy file-by-file
+          echo "--- Copying individual files to ${MAVEN_CONFIG} at $(date)" >> "${log}"
+          find . -type f -exec sh -eu -c '
+              log="${1}"
+              shift
+              reflink="${1}"
+              shift
+              for f in "$@" ; do
+                  if [ ! -e "${MAVEN_CONFIG}/${f}" ] || [ -e "${f}.override" ] ; then
+                      mkdir -p "${MAVEN_CONFIG}/$(dirname "${f}")"
+                      cp -rv ${reflink} "${f}" "${MAVEN_CONFIG}/${f}" >> "${log}"
+                  fi
+              done
+          ' _ "${log}" "${reflink}" {} +
+      fi
+      echo >> "${log}"
+  else
+    echo "Can not write to ${log}. Wrong volume permissions? Carrying on ..."
+  fi
+}
+
+owd="$(pwd)"
+copy_reference_files
+unset MAVEN_CONFIG
+
+cd "${owd}"
+unset owd
+
+exec "$@"

--- a/libericaopenjdk-17/settings-docker.xml
+++ b/libericaopenjdk-17/settings-docker.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>


### PR DESCRIPTION
This adds Liberica 17 CentOS and Alpine as requested in #278 

I had to modify github-action-generation.sh to work on Linux:
1. Override LC_COLLATE to preserve the sort ordering in other.yml
2. Switch references to gsed to sed. It looks like you're overriding the path to sed in command.sh and using sed about half the time, so I'm hoping this doesn't break on Mac, but either of these changes certainly could.

Happy to back them out, but I assume other submitters are occasionally working around these issues.

Thanks!
