### PR TITLE
Authenticate binaries before installation:

### DIFF
--- a/amazoncorretto-11/Dockerfile
+++ b/amazoncorretto-11/Dockerfile
@@ -1,23 +1,35 @@
 FROM amazoncorretto:11
 
-RUN yum install -y tar which gzip \
-  && rm -rf /var/cache/yum/* \
-  && yum clean all
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && yum install -y tar which gzip \
+  && yum clean all \
+  && rm -rf /var/cache/yum/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/amazoncorretto-17/Dockerfile
+++ b/amazoncorretto-17/Dockerfile
@@ -1,23 +1,35 @@
 FROM amazoncorretto:17
 
-RUN yum install -y tar which gzip \
-  && rm -rf /var/cache/yum/* \
-  && yum clean all
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && yum install -y tar which gzip \
+  && yum clean all \
+  && rm -rf /var/cache/yum/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/amazoncorretto-19/Dockerfile
+++ b/amazoncorretto-19/Dockerfile
@@ -1,23 +1,35 @@
 FROM amazoncorretto:19
 
-RUN yum install -y tar which gzip \
-  && rm -rf /var/cache/yum/* \
-  && yum clean all
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && yum install -y tar which gzip \
+  && yum clean all \
+  && rm -rf /var/cache/yum/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/amazoncorretto-8/Dockerfile
+++ b/amazoncorretto-8/Dockerfile
@@ -1,26 +1,38 @@
 FROM amazoncorretto:8
 
-RUN yum install -y tar which gzip \
-  && rm -rf /var/cache/yum/* \
-  && yum clean all
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 # Workaround https://github.com/corretto/corretto-8-docker/pull/32
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto
+
+RUN set -x \
+  && yum install -y tar which gzip \
+  && yum clean all \
+  && rm -rf /var/cache/yum/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/azulzulu-11-alpine/Dockerfile
+++ b/azulzulu-11-alpine/Dockerfile
@@ -1,21 +1,34 @@
 FROM azul/zulu-openjdk-alpine:11
 
-RUN apk add --no-cache curl tar bash procps
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apk add --no-cache bash procps curl tar gnupg \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apk del gnupg \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/azulzulu-11/Dockerfile
+++ b/azulzulu-11/Dockerfile
@@ -1,23 +1,36 @@
 FROM azul/zulu-openjdk:11
 
-RUN apt-get -qq update \
-    && apt-get -qqy install curl \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/azulzulu-17-alpine/Dockerfile
+++ b/azulzulu-17-alpine/Dockerfile
@@ -1,21 +1,34 @@
 FROM azul/zulu-openjdk-alpine:17
 
-RUN apk add --no-cache curl tar bash procps
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apk add --no-cache bash procps curl tar gnupg \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apk del gnupg \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/azulzulu-17/Dockerfile
+++ b/azulzulu-17/Dockerfile
@@ -1,23 +1,36 @@
 FROM azul/zulu-openjdk:17
 
-RUN apt-get -qq update \
-    && apt-get -qqy install curl \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-11-alpine/Dockerfile
+++ b/eclipse-temurin-11-alpine/Dockerfile
@@ -1,21 +1,34 @@
 FROM eclipse-temurin:11-jdk-alpine
 
-RUN apk add --no-cache curl tar bash procps
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apk add --no-cache bash procps curl tar gnupg \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apk del gnupg \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-11-focal/Dockerfile
+++ b/eclipse-temurin-11-focal/Dockerfile
@@ -1,23 +1,36 @@
 FROM eclipse-temurin:11-jdk-focal
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-11/Dockerfile
+++ b/eclipse-temurin-11/Dockerfile
@@ -1,23 +1,36 @@
 FROM eclipse-temurin:11-jdk
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-17-alpine/Dockerfile
+++ b/eclipse-temurin-17-alpine/Dockerfile
@@ -1,21 +1,34 @@
 FROM eclipse-temurin:17-jdk-alpine
 
-RUN apk add --no-cache curl tar bash procps
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apk add --no-cache bash procps curl tar gnupg \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apk del gnupg \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-17-focal/Dockerfile
+++ b/eclipse-temurin-17-focal/Dockerfile
@@ -1,23 +1,36 @@
 FROM eclipse-temurin:17-jdk-focal
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-17/Dockerfile
+++ b/eclipse-temurin-17/Dockerfile
@@ -1,23 +1,36 @@
 FROM eclipse-temurin:17-jdk
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-19-alpine/Dockerfile
+++ b/eclipse-temurin-19-alpine/Dockerfile
@@ -1,21 +1,34 @@
 FROM eclipse-temurin:19-jdk-alpine
 
-RUN apk add --no-cache curl tar bash procps
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apk add --no-cache bash procps curl tar gnupg \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apk del gnupg \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-19-focal/Dockerfile
+++ b/eclipse-temurin-19-focal/Dockerfile
@@ -1,23 +1,36 @@
 FROM eclipse-temurin:19-jdk-focal
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-19/Dockerfile
+++ b/eclipse-temurin-19/Dockerfile
@@ -1,23 +1,36 @@
 FROM eclipse-temurin:19-jdk
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-8-alpine/Dockerfile
+++ b/eclipse-temurin-8-alpine/Dockerfile
@@ -1,21 +1,34 @@
 FROM eclipse-temurin:8-jdk-alpine
 
-RUN apk add --no-cache curl tar bash procps
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apk add --no-cache bash procps curl tar gnupg \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apk del gnupg \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-8-focal/Dockerfile
+++ b/eclipse-temurin-8-focal/Dockerfile
@@ -1,23 +1,36 @@
 FROM eclipse-temurin:8-jdk-focal
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/eclipse-temurin-8/Dockerfile
+++ b/eclipse-temurin-8/Dockerfile
@@ -1,23 +1,36 @@
 FROM eclipse-temurin:8-jdk
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/ibm-semeru-11-focal/Dockerfile
+++ b/ibm-semeru-11-focal/Dockerfile
@@ -1,23 +1,36 @@
 FROM ibm-semeru-runtimes:open-11-jdk-focal
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/ibm-semeru-17-focal/Dockerfile
+++ b/ibm-semeru-17-focal/Dockerfile
@@ -1,23 +1,36 @@
 FROM ibm-semeru-runtimes:open-17-jdk-focal
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/ibmjava-8/Dockerfile
+++ b/ibmjava-8/Dockerfile
@@ -1,21 +1,36 @@
 FROM ibmjava:8-sdk
 
-RUN apt-get update && apt-get install -y curl
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/libericaopenjdk-11-alpine/Dockerfile
+++ b/libericaopenjdk-11-alpine/Dockerfile
@@ -1,21 +1,34 @@
 FROM bellsoft/liberica-openjdk-alpine:11
 
-RUN apk add --no-cache curl tar bash procps
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apk add --no-cache bash procps curl tar gnupg \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apk del gnupg \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/libericaopenjdk-11-debian/Dockerfile
+++ b/libericaopenjdk-11-debian/Dockerfile
@@ -3,17 +3,34 @@ FROM bellsoft/liberica-openjdk-debian:11
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/libericaopenjdk-11/Dockerfile
+++ b/libericaopenjdk-11/Dockerfile
@@ -3,17 +3,30 @@ FROM bellsoft/liberica-openjdk-centos:11
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/libericaopenjdk-17-alpine/Dockerfile
+++ b/libericaopenjdk-17-alpine/Dockerfile
@@ -1,21 +1,34 @@
 FROM bellsoft/liberica-openjdk-alpine:17
 
-RUN apk add --no-cache curl tar bash procps
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apk add --no-cache bash procps curl tar gnupg \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apk del gnupg \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/libericaopenjdk-17-debian/Dockerfile
+++ b/libericaopenjdk-17-debian/Dockerfile
@@ -3,17 +3,34 @@ FROM bellsoft/liberica-openjdk-debian:17
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/libericaopenjdk-17/Dockerfile
+++ b/libericaopenjdk-17/Dockerfile
@@ -3,17 +3,30 @@ FROM bellsoft/liberica-openjdk-centos:17
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/libericaopenjdk-8-alpine/Dockerfile
+++ b/libericaopenjdk-8-alpine/Dockerfile
@@ -1,21 +1,34 @@
 FROM bellsoft/liberica-openjdk-alpine:8
 
-RUN apk add --no-cache curl tar bash procps
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apk add --no-cache bash procps curl tar gnupg \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apk del gnupg \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/libericaopenjdk-8-debian/Dockerfile
+++ b/libericaopenjdk-8-debian/Dockerfile
@@ -3,17 +3,34 @@ FROM bellsoft/liberica-openjdk-debian:8
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/libericaopenjdk-8/Dockerfile
+++ b/libericaopenjdk-8/Dockerfile
@@ -3,17 +3,30 @@ FROM bellsoft/liberica-openjdk-centos:8
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/microsoft-openjdk-11-ubuntu/Dockerfile
+++ b/microsoft-openjdk-11-ubuntu/Dockerfile
@@ -1,23 +1,36 @@
 FROM mcr.microsoft.com/openjdk/jdk:11-ubuntu
 
-RUN apt-get update \
-  && apt-get install -y curl git \
-  && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/microsoft-openjdk-16-ubuntu/Dockerfile
+++ b/microsoft-openjdk-16-ubuntu/Dockerfile
@@ -1,23 +1,36 @@
 FROM mcr.microsoft.com/openjdk/jdk:16-ubuntu
 
-RUN apt-get update \
-  && apt-get install -y curl git \
-  && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/microsoft-openjdk-17-ubuntu/Dockerfile
+++ b/microsoft-openjdk-17-ubuntu/Dockerfile
@@ -1,23 +1,36 @@
 FROM mcr.microsoft.com/openjdk/jdk:17-ubuntu
 
-RUN apt-get update \
-  && apt-get install -y curl git \
-  && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/openjdk-18-slim/Dockerfile
+++ b/openjdk-18-slim/Dockerfile
@@ -1,23 +1,36 @@
 FROM openjdk:18-jdk-slim
 
-RUN apt-get update \
-  && apt-get install -y curl procps \
-  && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl procps gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y ca-certificates gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/openjdk-18/Dockerfile
+++ b/openjdk-18/Dockerfile
@@ -1,21 +1,33 @@
 FROM openjdk:18-jdk-oraclelinux8
 
-RUN microdnf install findutils git
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && microdnf install findutils git \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/sapmachine-11/Dockerfile
+++ b/sapmachine-11/Dockerfile
@@ -1,23 +1,36 @@
 FROM sapmachine:11
 
-RUN apt-get update \
-    && apt-get install -y curl git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/

--- a/sapmachine-17/Dockerfile
+++ b/sapmachine-17/Dockerfile
@@ -1,23 +1,36 @@
 FROM sapmachine:17
 
-RUN apt-get update \
-    && apt-get install -y curl git \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG MAVEN_VERSION=3.8.7
 ARG USER_HOME_DIR="/root"
 ARG SHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && for key in \
+    6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
+  ; do \
+    gpg --batch --keyserver hkps://pgp.surf.nl --recv-keys "$key" || \
+    gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
+  # GNUPGHOME may fail to delete even with -rf
+  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+  && apt-get remove --purge --autoremove -y gnupg dirmngr \
+  # smoke test
+  && mvn --version
 
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/


### PR DESCRIPTION
All images should authenticate maven binaries. 

And: 

+ Shell debug
+ Smoke test
+ Cleanup image after installation

Signed-off-by: Jérôme Benoit <jerome.benoit@sap.com>