### PR TITLE
Update actions to silence Node.js 12 warnings and deprecations

### DIFF
--- a/.github/workflows/_template.yml
+++ b/.github/workflows/_template.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup BATS
         uses: mig4/setup-bats@v1.2.0
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update submodules
         run: git submodule update --init
 
@@ -42,7 +42,7 @@ jobs:
         uses: sigstore/cosign-installer@main
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
 
@@ -90,7 +90,7 @@ jobs:
           TAGS="${TAGS//'%'/'%25'}"
           TAGS="${TAGS//$'\n'/'%0A'}"
           TAGS="${TAGS//$'\r'/'%0D'}"
-          echo "::set-output name=tags::$TAGS"
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
         id: retrieve-tags
 
       # Build and push Docker image with Buildx (don't push on PR)


### PR DESCRIPTION
This PR intends to address the Node.js 12 deprecation warnings by updating various actions, and mitigates the `set-ouput` warning by switching the syntax.

![Screenshot 2022-12-31 at 19 58 07](https://user-images.githubusercontent.com/13383509/210153321-927bda0f-2d07-4ec3-8b00-917288d3ab97.png)