### PR TITLE
Include ssh client on Temurin distributions

### DIFF
--- a/eclipse-temurin-11-focal/Dockerfile
+++ b/eclipse-temurin-11-focal/Dockerfile
@@ -10,7 +10,7 @@ ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 RUN set -x \
   && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && apt-get install -y ca-certificates curl git openssh-client gnupg dirmngr --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \

--- a/eclipse-temurin-11/Dockerfile
+++ b/eclipse-temurin-11/Dockerfile
@@ -10,7 +10,7 @@ ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 RUN set -x \
   && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && apt-get install -y ca-certificates curl git openssh-client gnupg dirmngr --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \

--- a/eclipse-temurin-17-focal/Dockerfile
+++ b/eclipse-temurin-17-focal/Dockerfile
@@ -10,7 +10,7 @@ ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 RUN set -x \
   && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && apt-get install -y ca-certificates curl git openssh-client gnupg dirmngr --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \

--- a/eclipse-temurin-17/Dockerfile
+++ b/eclipse-temurin-17/Dockerfile
@@ -10,7 +10,7 @@ ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 RUN set -x \
   && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && apt-get install -y ca-certificates curl git openssh-client gnupg dirmngr --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \

--- a/eclipse-temurin-19-focal/Dockerfile
+++ b/eclipse-temurin-19-focal/Dockerfile
@@ -10,7 +10,7 @@ ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 RUN set -x \
   && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && apt-get install -y ca-certificates curl git openssh-client gnupg dirmngr --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \

--- a/eclipse-temurin-19/Dockerfile
+++ b/eclipse-temurin-19/Dockerfile
@@ -10,7 +10,7 @@ ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 RUN set -x \
   && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && apt-get install -y ca-certificates curl git openssh-client gnupg dirmngr --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \

--- a/eclipse-temurin-8-focal/Dockerfile
+++ b/eclipse-temurin-8-focal/Dockerfile
@@ -10,7 +10,7 @@ ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 RUN set -x \
   && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && apt-get install -y ca-certificates curl git openssh-client gnupg dirmngr --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \

--- a/eclipse-temurin-8/Dockerfile
+++ b/eclipse-temurin-8/Dockerfile
@@ -10,7 +10,7 @@ ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 RUN set -x \
   && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
+  && apt-get install -y ca-certificates curl git openssh-client gnupg dirmngr --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \


### PR DESCRIPTION
Fix https://github.com/carlossg/docker-maven/issues/339

I will argue is a common use case when using maven release plugin and GIT_SSH_COMMAND env var to configure SSH option.
