### PR TITLE
chore: install in one main image

### DIFF
--- a/Dockerfile-template
+++ b/Dockerfile-template
@@ -1,7 +1,3 @@
-FROM amazoncorretto:19
-
-RUN yum install -y tar which gzip # TODO remove
-
 # common for all images
 ENV MAVEN_HOME /usr/share/maven
 

--- a/amazoncorretto-11/Dockerfile
+++ b/amazoncorretto-11/Dockerfile
@@ -1,38 +1,19 @@
 FROM amazoncorretto:11
 
+RUN yum install -y tar which gzip # TODO remove
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && yum install -y tar which gzip \
-  && yum clean all \
-  && rm -rf /var/cache/yum/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-17/Dockerfile
+++ b/amazoncorretto-17/Dockerfile
@@ -1,38 +1,19 @@
 FROM amazoncorretto:17
 
+RUN yum install -y tar which gzip # TODO remove
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && yum install -y tar which gzip \
-  && yum clean all \
-  && rm -rf /var/cache/yum/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-8/Dockerfile
+++ b/amazoncorretto-8/Dockerfile
@@ -1,41 +1,19 @@
 FROM amazoncorretto:8
 
+RUN yum install -y tar which gzip # TODO remove
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-# Workaround https://github.com/corretto/corretto-8-docker/pull/32
-ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto
-
-RUN set -x \
-  && yum install -y tar which gzip \
-  && yum clean all \
-  && rm -rf /var/cache/yum/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-11-alpine/Dockerfile
+++ b/azulzulu-11-alpine/Dockerfile
@@ -1,37 +1,19 @@
 FROM azul/zulu-openjdk-alpine:11
 
+RUN apk add --no-cache bash procps curl tar
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apk add --no-cache bash procps curl tar gnupg \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apk del gnupg \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-11/Dockerfile
+++ b/azulzulu-11/Dockerfile
@@ -1,39 +1,21 @@
 FROM azul/zulu-openjdk:11
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-17-alpine/Dockerfile
+++ b/azulzulu-17-alpine/Dockerfile
@@ -1,37 +1,19 @@
 FROM azul/zulu-openjdk-alpine:17
 
+RUN apk add --no-cache bash procps curl tar
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apk add --no-cache bash procps curl tar gnupg \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apk del gnupg \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-17/Dockerfile
+++ b/azulzulu-17/Dockerfile
@@ -1,39 +1,21 @@
 FROM azul/zulu-openjdk:17
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-11-alpine/Dockerfile
+++ b/eclipse-temurin-11-alpine/Dockerfile
@@ -1,37 +1,19 @@
 FROM eclipse-temurin:11-jdk-alpine
 
+RUN apk add --no-cache bash procps curl tar
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apk add --no-cache bash procps curl tar gnupg \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apk del gnupg \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-11-focal/Dockerfile
+++ b/eclipse-temurin-11-focal/Dockerfile
@@ -1,39 +1,21 @@
 FROM eclipse-temurin:11-jdk-focal
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-11/Dockerfile
+++ b/eclipse-temurin-11/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jdk
+FROM eclipse-temurin:11-jdk as builder
 
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
@@ -8,32 +8,44 @@ ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binarie
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
-RUN set -x \
-  && apt-get update \
+RUN apt-get update \
   && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc
+RUN export GNUPGHOME="$(mktemp -d)" \
   && for key in \
   6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
   29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
   ; do \
   gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
   done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
+  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz
+RUN mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
   && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
+  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+# smoke test
+RUN mvn --version
 
+
+FROM eclipse-temurin:11-jdk
+
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=builder ${MAVEN_HOME} ${MAVEN_HOME}
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY settings-docker.xml /usr/share/maven/ref/
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=3.9.0
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-17-alpine/Dockerfile
+++ b/eclipse-temurin-17-alpine/Dockerfile
@@ -1,37 +1,19 @@
 FROM eclipse-temurin:17-jdk-alpine
 
+RUN apk add --no-cache bash procps curl tar
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apk add --no-cache bash procps curl tar gnupg \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apk del gnupg \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-17-focal/Dockerfile
+++ b/eclipse-temurin-17-focal/Dockerfile
@@ -1,39 +1,21 @@
 FROM eclipse-temurin:17-jdk-focal
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-17/Dockerfile
+++ b/eclipse-temurin-17/Dockerfile
@@ -1,39 +1,21 @@
 FROM eclipse-temurin:17-jdk
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-19-alpine/Dockerfile
+++ b/eclipse-temurin-19-alpine/Dockerfile
@@ -1,37 +1,19 @@
 FROM eclipse-temurin:19-jdk-alpine
 
+RUN apk add --no-cache bash procps curl tar
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apk add --no-cache bash procps curl tar gnupg \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apk del gnupg \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-19-focal/Dockerfile
+++ b/eclipse-temurin-19-focal/Dockerfile
@@ -1,39 +1,21 @@
 FROM eclipse-temurin:19-jdk-focal
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-19/Dockerfile
+++ b/eclipse-temurin-19/Dockerfile
@@ -1,39 +1,20 @@
 FROM eclipse-temurin:19-jdk
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-8-alpine/Dockerfile
+++ b/eclipse-temurin-8-alpine/Dockerfile
@@ -1,37 +1,19 @@
 FROM eclipse-temurin:8-jdk-alpine
 
+RUN apk add --no-cache bash procps curl tar
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apk add --no-cache bash procps curl tar gnupg \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apk del gnupg \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-8-focal/Dockerfile
+++ b/eclipse-temurin-8-focal/Dockerfile
@@ -1,39 +1,21 @@
 FROM eclipse-temurin:8-jdk-focal
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-8/Dockerfile
+++ b/eclipse-temurin-8/Dockerfile
@@ -1,39 +1,21 @@
 FROM eclipse-temurin:8-jdk
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -29,7 +29,7 @@ generate-version() {
 		return 1
 	fi
 
-	from="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
+	from="$(grep FROM eclipse-temurin-8/Dockerfile | tail -n 1 | awk 'toupper($1) == "FROM" { print $2 }')"
 	arches="$(bashbrew cat --format '{{- join ", " .TagEntry.Architectures -}}' "$from")"
 	constraints="$(bashbrew cat --format '{{ join ", " .TagEntry.Constraints -}}' "$from")"
 
@@ -43,6 +43,7 @@ generate-version() {
 }
 
 echo 'Maintainers: Carlos Sanchez <carlos@apache.org> (@carlossg)'
+echo 'Builder: buildkit'
 echo "GitRepo: $url"
 
 for version in "${all_dirs[@]}"; do

--- a/ibm-semeru-11-focal/Dockerfile
+++ b/ibm-semeru-11-focal/Dockerfile
@@ -1,39 +1,21 @@
 FROM ibm-semeru-runtimes:open-11-jdk-focal
 
+RUN apt-get update \
+  && apt-get install -y git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibm-semeru-17-focal/Dockerfile
+++ b/ibm-semeru-17-focal/Dockerfile
@@ -1,39 +1,21 @@
 FROM ibm-semeru-runtimes:open-17-jdk-focal
 
+RUN apt-get update \
+  && apt-get install -y git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibmjava-8/Dockerfile
+++ b/ibmjava-8/Dockerfile
@@ -1,39 +1,21 @@
 FROM ibmjava:8-sdk
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-11-alpine/Dockerfile
+++ b/libericaopenjdk-11-alpine/Dockerfile
@@ -1,37 +1,19 @@
 FROM bellsoft/liberica-openjdk-alpine:11
 
+RUN apk add --no-cache bash procps curl tar
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apk add --no-cache bash procps curl tar gnupg \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apk del gnupg \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-11-debian/Dockerfile
+++ b/libericaopenjdk-11-debian/Dockerfile
@@ -1,39 +1,21 @@
 FROM bellsoft/liberica-openjdk-debian:11
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-11/Dockerfile
+++ b/libericaopenjdk-11/Dockerfile
@@ -1,35 +1,17 @@
 FROM bellsoft/liberica-openjdk-centos:11
 
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-17-alpine/Dockerfile
+++ b/libericaopenjdk-17-alpine/Dockerfile
@@ -1,37 +1,19 @@
 FROM bellsoft/liberica-openjdk-alpine:17
 
+RUN apk add --no-cache bash procps curl tar
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apk add --no-cache bash procps curl tar gnupg \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apk del gnupg \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-17-debian/Dockerfile
+++ b/libericaopenjdk-17-debian/Dockerfile
@@ -1,39 +1,21 @@
 FROM bellsoft/liberica-openjdk-debian:17
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-17/Dockerfile
+++ b/libericaopenjdk-17/Dockerfile
@@ -1,35 +1,17 @@
 FROM bellsoft/liberica-openjdk-centos:17
 
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-8-alpine/Dockerfile
+++ b/libericaopenjdk-8-alpine/Dockerfile
@@ -1,37 +1,19 @@
 FROM bellsoft/liberica-openjdk-alpine:8
 
+RUN apk add --no-cache bash procps curl tar
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apk add --no-cache bash procps curl tar gnupg \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apk del gnupg \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-8-debian/Dockerfile
+++ b/libericaopenjdk-8-debian/Dockerfile
@@ -1,39 +1,21 @@
 FROM bellsoft/liberica-openjdk-debian:8
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-8/Dockerfile
+++ b/libericaopenjdk-8/Dockerfile
@@ -1,35 +1,17 @@
 FROM bellsoft/liberica-openjdk-centos:8
 
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-11-ubuntu/Dockerfile
+++ b/microsoft-openjdk-11-ubuntu/Dockerfile
@@ -1,39 +1,21 @@
 FROM mcr.microsoft.com/openjdk/jdk:11-ubuntu
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-16-ubuntu/Dockerfile
+++ b/microsoft-openjdk-16-ubuntu/Dockerfile
@@ -1,39 +1,21 @@
 FROM mcr.microsoft.com/openjdk/jdk:16-ubuntu
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-17-ubuntu/Dockerfile
+++ b/microsoft-openjdk-17-ubuntu/Dockerfile
@@ -1,39 +1,21 @@
 FROM mcr.microsoft.com/openjdk/jdk:17-ubuntu
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-11/Dockerfile
+++ b/sapmachine-11/Dockerfile
@@ -1,39 +1,21 @@
 FROM sapmachine:11
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-17/Dockerfile
+++ b/sapmachine-17/Dockerfile
@@ -1,39 +1,21 @@
 FROM sapmachine:17
 
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.0-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.0-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
 ARG MAVEN_VERSION=3.9.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=1ea149f4e48bc7b34d554aef86f948eca7df4e7874e30caf449f3708e4f8487c71a5e5c072a05f17c60406176ebeeaf56b5f895090c7346f8238e2da06cf6ecd
-ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-
-RUN set -x \
-  && apt-get update \
-  && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && for key in \
-  6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
-  29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
-  ; do \
-  gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && gpg --batch --verify apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
-  && tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C ${MAVEN_HOME} --strip-components=1 \
-  # GNUPGHOME may fail to delete even with -rf
-  && (rm -rf "$GNUPGHOME" apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc apache-maven-${MAVEN_VERSION}-bin.tar.gz || true) \
-  && ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
-  && apt-get remove --purge --autoremove -y gnupg dirmngr \
-  # smoke test
-  && mvn --version
-
-COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
-COPY settings-docker.xml /usr/share/maven/ref/
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -22,14 +22,14 @@ load test_helpers
 }
 
 @test "$SUT_TAG create test container" {
-	version="$(grep 'ARG MAVEN_VERSION' $BATS_TEST_DIRNAME/../$SUT_TAG/Dockerfile | sed -e 's/ARG MAVEN_VERSION=//')"
+	version="$(grep -m 1 'ARG MAVEN_VERSION' $BATS_TEST_DIRNAME/../$SUT_TAG/Dockerfile | sed -e 's/ARG MAVEN_VERSION=//')"
 	run docker run --rm $SUT_IMAGE:$SUT_TAG mvn -version
 	assert_success
 	assert_line -p "Apache Maven $version "
 }
 
 @test "$SUT_TAG create test container (-u 11337:11337)" {
-	version="$(grep 'ARG MAVEN_VERSION' $BATS_TEST_DIRNAME/../$SUT_TAG/Dockerfile | sed -e 's/ARG MAVEN_VERSION=//')"
+	version="$(grep -m 1 'ARG MAVEN_VERSION' $BATS_TEST_DIRNAME/../$SUT_TAG/Dockerfile | sed -e 's/ARG MAVEN_VERSION=//')"
 	run docker run --rm -u 11337:11337 $SUT_IMAGE:$SUT_TAG mvn -version
 	assert_success
 	assert_line -p "Apache Maven $version "
@@ -131,7 +131,8 @@ load test_helpers
 		[[ "$SUT_TAG" == "amazoncorretto-"* ]] ||
 			[[ "$SUT_TAG" == libericaopenjdk-? ]] ||
 			[[ "$SUT_TAG" == libericaopenjdk-?? ]] ||
-			[[ "$SUT_TAG" == openjdk-?? ]]
+			[[ "$SUT_TAG" == openjdk-?? ]] ||
+			[[ "$SUT_TAG" == sapmachine-?? ]]
 	); then
 		assert_success
 	else


### PR DESCRIPTION
and use COPY from in the other ones
to avoid having to install all the tools for download and verification in each image

following advice from https://github.com/docker-library/official-images/pull/14083#issuecomment-1433740677