### PR TITLE
Verify corretto apt key & make corretto-20-debian image install the java-20 package

### DIFF
--- a/amazoncorretto-11-debian-slim/Dockerfile
+++ b/amazoncorretto-11-debian-slim/Dockerfile
@@ -1,9 +1,13 @@
 FROM debian:stable-slim
 
-# install corretto
+# install corretto after verifying that the key is the one we expect.
 RUN apt-get update \
   && apt-get install -y curl gnupg \
-  && curl https://apt.corretto.aws/corretto.key | gpg --dearmor | dd of=/usr/share/keyrings/corretto.gpg \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && curl -fL https://apt.corretto.aws/corretto.key | gpg --batch --import \
+  && gpg --batch --export '6DC3636DAE534049C8B94623A122542AB04F24E3' > /usr/share/keyrings/corretto.gpg \
+  && rm -r "$GNUPGHOME" \
+  && unset GNUPGHOME \
   && echo "deb [signed-by=/usr/share/keyrings/corretto.gpg] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
   && apt-get update \
   && apt-get remove --purge --autoremove -y curl gnupg \

--- a/amazoncorretto-17-debian-slim/Dockerfile
+++ b/amazoncorretto-17-debian-slim/Dockerfile
@@ -1,9 +1,13 @@
 FROM debian:stable-slim
 
-# install corretto
+# install corretto after verifying that the key is the one we expect.
 RUN apt-get update \
   && apt-get install -y curl gnupg \
-  && curl https://apt.corretto.aws/corretto.key | gpg --dearmor | dd of=/usr/share/keyrings/corretto.gpg \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && curl -fL https://apt.corretto.aws/corretto.key | gpg --batch --import \
+  && gpg --batch --export '6DC3636DAE534049C8B94623A122542AB04F24E3' > /usr/share/keyrings/corretto.gpg \
+  && rm -r "$GNUPGHOME" \
+  && unset GNUPGHOME \
   && echo "deb [signed-by=/usr/share/keyrings/corretto.gpg] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
   && apt-get update \
   && apt-get remove --purge --autoremove -y curl gnupg \

--- a/amazoncorretto-19-debian-slim/Dockerfile
+++ b/amazoncorretto-19-debian-slim/Dockerfile
@@ -1,9 +1,13 @@
 FROM debian:stable-slim
 
-# install corretto
+# install corretto after verifying that the key is the one we expect.
 RUN apt-get update \
   && apt-get install -y curl gnupg \
-  && curl https://apt.corretto.aws/corretto.key | gpg --dearmor | dd of=/usr/share/keyrings/corretto.gpg \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && curl -fL https://apt.corretto.aws/corretto.key | gpg --batch --import \
+  && gpg --batch --export '6DC3636DAE534049C8B94623A122542AB04F24E3' > /usr/share/keyrings/corretto.gpg \
+  && rm -r "$GNUPGHOME" \
+  && unset GNUPGHOME \
   && echo "deb [signed-by=/usr/share/keyrings/corretto.gpg] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
   && apt-get update \
   && apt-get remove --purge --autoremove -y curl gnupg \

--- a/amazoncorretto-20-debian-slim/Dockerfile
+++ b/amazoncorretto-20-debian-slim/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
   && echo "deb [signed-by=/usr/share/keyrings/corretto.gpg] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
   && apt-get update \
   && apt-get remove --purge --autoremove -y curl gnupg \
-  && apt-get install -y java-19-amazon-corretto-jdk \
+  && apt-get install -y java-20-amazon-corretto-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images

--- a/amazoncorretto-20-debian-slim/Dockerfile
+++ b/amazoncorretto-20-debian-slim/Dockerfile
@@ -1,9 +1,13 @@
 FROM debian:stable-slim
 
-# install corretto
+# install corretto after verifying that the key is the one we expect.
 RUN apt-get update \
   && apt-get install -y curl gnupg \
-  && curl https://apt.corretto.aws/corretto.key | gpg --dearmor | dd of=/usr/share/keyrings/corretto.gpg \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && curl -fL https://apt.corretto.aws/corretto.key | gpg --batch --import \
+  && gpg --batch --export '6DC3636DAE534049C8B94623A122542AB04F24E3' > /usr/share/keyrings/corretto.gpg \
+  && rm -r "$GNUPGHOME" \
+  && unset GNUPGHOME \
   && echo "deb [signed-by=/usr/share/keyrings/corretto.gpg] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
   && apt-get update \
   && apt-get remove --purge --autoremove -y curl gnupg \

--- a/amazoncorretto-8-debian-slim/Dockerfile
+++ b/amazoncorretto-8-debian-slim/Dockerfile
@@ -1,9 +1,13 @@
 FROM debian:stable-slim
 
-# install corretto
+# install corretto after verifying that the key is the one we expect.
 RUN apt-get update \
   && apt-get install -y curl gnupg \
-  && curl https://apt.corretto.aws/corretto.key | gpg --dearmor | dd of=/usr/share/keyrings/corretto.gpg \
+  && export GNUPGHOME="$(mktemp -d)" \
+  && curl -fL https://apt.corretto.aws/corretto.key | gpg --batch --import \
+  && gpg --batch --export '6DC3636DAE534049C8B94623A122542AB04F24E3' > /usr/share/keyrings/corretto.gpg \
+  && rm -r "$GNUPGHOME" \
+  && unset GNUPGHOME \
   && echo "deb [signed-by=/usr/share/keyrings/corretto.gpg] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
   && apt-get update \
   && apt-get remove --purge --autoremove -y curl gnupg \


### PR DESCRIPTION
@carlossg I saw the comment on https://github.com/docker-library/official-images/pull/14308#issuecomment-1496758237 about passing downloaded keys via gpg so I've tried to do that here in this PR.

I also changed the corretto-20-debian image to install `java-20-amazon-correto-jdk` -- I think it was accidentally installing 19.