### PR TITLE
Rename corretto debian variants

### DIFF
--- a/.github/workflows/amazoncorretto-11-debian.yml
+++ b/.github/workflows/amazoncorretto-11-debian.yml
@@ -1,12 +1,12 @@
-name: amazoncorretto-8-debian-slim
+name: amazoncorretto-11-debian
 
 on:
   push:
     branches:
     - main
     paths:
-      - "amazoncorretto-8-debian-slim/**"
-      - .github/workflows/amazoncorretto-8-debian-slim.yml
+      - "amazoncorretto-11-debian/**"
+      - .github/workflows/amazoncorretto-11-debian.yml
       - .github/workflows/_template.yml
       - common.sh
       - tags-for-dir.sh
@@ -15,8 +15,8 @@ on:
       - "!tests/*.windows"
   pull_request:
     paths:
-      - "amazoncorretto-8-debian-slim/**"
-      - .github/workflows/amazoncorretto-8-debian-slim.yml
+      - "amazoncorretto-11-debian/**"
+      - .github/workflows/amazoncorretto-11-debian.yml
       - .github/workflows/_template.yml
       - common.sh
       - tags-for-dir.sh
@@ -28,5 +28,5 @@ jobs:
   build:
     uses: ./.github/workflows/_template.yml
     with:
-      directory: amazoncorretto-8-debian-slim
+      directory: amazoncorretto-11-debian
     secrets: inherit

--- a/.github/workflows/amazoncorretto-17-debian.yml
+++ b/.github/workflows/amazoncorretto-17-debian.yml
@@ -1,12 +1,12 @@
-name: amazoncorretto-11-debian-slim
+name: amazoncorretto-17-debian
 
 on:
   push:
     branches:
     - main
     paths:
-      - "amazoncorretto-11-debian-slim/**"
-      - .github/workflows/amazoncorretto-11-debian-slim.yml
+      - "amazoncorretto-17-debian/**"
+      - .github/workflows/amazoncorretto-17-debian.yml
       - .github/workflows/_template.yml
       - common.sh
       - tags-for-dir.sh
@@ -15,8 +15,8 @@ on:
       - "!tests/*.windows"
   pull_request:
     paths:
-      - "amazoncorretto-11-debian-slim/**"
-      - .github/workflows/amazoncorretto-11-debian-slim.yml
+      - "amazoncorretto-17-debian/**"
+      - .github/workflows/amazoncorretto-17-debian.yml
       - .github/workflows/_template.yml
       - common.sh
       - tags-for-dir.sh
@@ -28,5 +28,5 @@ jobs:
   build:
     uses: ./.github/workflows/_template.yml
     with:
-      directory: amazoncorretto-11-debian-slim
+      directory: amazoncorretto-17-debian
     secrets: inherit

--- a/.github/workflows/amazoncorretto-19-debian.yml
+++ b/.github/workflows/amazoncorretto-19-debian.yml
@@ -1,12 +1,12 @@
-name: amazoncorretto-19-debian-slim
+name: amazoncorretto-19-debian
 
 on:
   push:
     branches:
     - main
     paths:
-      - "amazoncorretto-19-debian-slim/**"
-      - .github/workflows/amazoncorretto-19-debian-slim.yml
+      - "amazoncorretto-19-debian/**"
+      - .github/workflows/amazoncorretto-19-debian.yml
       - .github/workflows/_template.yml
       - common.sh
       - tags-for-dir.sh
@@ -15,8 +15,8 @@ on:
       - "!tests/*.windows"
   pull_request:
     paths:
-      - "amazoncorretto-19-debian-slim/**"
-      - .github/workflows/amazoncorretto-19-debian-slim.yml
+      - "amazoncorretto-19-debian/**"
+      - .github/workflows/amazoncorretto-19-debian.yml
       - .github/workflows/_template.yml
       - common.sh
       - tags-for-dir.sh
@@ -28,5 +28,5 @@ jobs:
   build:
     uses: ./.github/workflows/_template.yml
     with:
-      directory: amazoncorretto-19-debian-slim
+      directory: amazoncorretto-19-debian
     secrets: inherit

--- a/.github/workflows/amazoncorretto-20-debian.yml
+++ b/.github/workflows/amazoncorretto-20-debian.yml
@@ -1,12 +1,12 @@
-name: amazoncorretto-20-debian-slim
+name: amazoncorretto-20-debian
 
 on:
   push:
     branches:
     - main
     paths:
-      - "amazoncorretto-20-debian-slim/**"
-      - .github/workflows/amazoncorretto-20-debian-slim.yml
+      - "amazoncorretto-20-debian/**"
+      - .github/workflows/amazoncorretto-20-debian.yml
       - .github/workflows/_template.yml
       - common.sh
       - tags-for-dir.sh
@@ -15,8 +15,8 @@ on:
       - "!tests/*.windows"
   pull_request:
     paths:
-      - "amazoncorretto-20-debian-slim/**"
-      - .github/workflows/amazoncorretto-20-debian-slim.yml
+      - "amazoncorretto-20-debian/**"
+      - .github/workflows/amazoncorretto-20-debian.yml
       - .github/workflows/_template.yml
       - common.sh
       - tags-for-dir.sh
@@ -28,5 +28,5 @@ jobs:
   build:
     uses: ./.github/workflows/_template.yml
     with:
-      directory: amazoncorretto-20-debian-slim
+      directory: amazoncorretto-20-debian
     secrets: inherit

--- a/.github/workflows/amazoncorretto-8-debian.yml
+++ b/.github/workflows/amazoncorretto-8-debian.yml
@@ -1,12 +1,12 @@
-name: amazoncorretto-17-debian-slim
+name: amazoncorretto-8-debian
 
 on:
   push:
     branches:
     - main
     paths:
-      - "amazoncorretto-17-debian-slim/**"
-      - .github/workflows/amazoncorretto-17-debian-slim.yml
+      - "amazoncorretto-8-debian/**"
+      - .github/workflows/amazoncorretto-8-debian.yml
       - .github/workflows/_template.yml
       - common.sh
       - tags-for-dir.sh
@@ -15,8 +15,8 @@ on:
       - "!tests/*.windows"
   pull_request:
     paths:
-      - "amazoncorretto-17-debian-slim/**"
-      - .github/workflows/amazoncorretto-17-debian-slim.yml
+      - "amazoncorretto-8-debian/**"
+      - .github/workflows/amazoncorretto-8-debian.yml
       - .github/workflows/_template.yml
       - common.sh
       - tags-for-dir.sh
@@ -28,5 +28,5 @@ jobs:
   build:
     uses: ./.github/workflows/_template.yml
     with:
-      directory: amazoncorretto-17-debian-slim
+      directory: amazoncorretto-8-debian
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ Only under `csanchez/maven` and `ghcr.io/carlossg/maven`:
 * [microsoft-openjdk-11-ubuntu](https://github.com/carlossg/docker-maven/blob/main/microsoft-openjdk-11-ubuntu/Dockerfile)
 * [microsoft-openjdk-16-ubuntu](https://github.com/carlossg/docker-maven/blob/main/microsoft-openjdk-16-ubuntu/Dockerfile)
 * [microsoft-openjdk-17-ubuntu](https://github.com/carlossg/docker-maven/blob/main/microsoft-openjdk-17-ubuntu/Dockerfile)
-* [amazoncorretto-8-debian-slim](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-8-debian-slim/Dockerfile)
-* [amazoncorretto-11-debian-slim](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-11-debian-slim/Dockerfile)
-* [amazoncorretto-17-debian-slim](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-17-debian-slim/Dockerfile)
-* [amazoncorretto-19-debian-slim](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-19-debian-slim/Dockerfile)
+* [amazoncorretto-8-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-8-debian/Dockerfile)
+* [amazoncorretto-11-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-11-debian/Dockerfile)
+* [amazoncorretto-17-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-17-debian/Dockerfile)
+* [amazoncorretto-19-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-19-debian/Dockerfile)
+* [amazoncorretto-20-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-20-debian/Dockerfile)
 
 ## Windows Based Images
 
@@ -198,15 +199,15 @@ Some come from the parent images and some are installed in this image for backwa
 |                               | git | curl | tar | bash | which | gzip | procps | gpg | ssh |
 |-------------------------------|-----|------|-----|------|-------|------|--------|-----|-----|
 | amazoncorretto-8              |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    |        | ✔️   |     |
-| amazoncorretto-8-debian-slim  |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
+| amazoncorretto-8-debian       |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
 | amazoncorretto-11             |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    |        | ✔️   |     |
-| amazoncorretto-11-debian-slim |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
+| amazoncorretto-11-debian      |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
 | amazoncorretto-17             |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    |        | ✔️   |     |
-| amazoncorretto-17-debian-slim |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
+| amazoncorretto-17-debian      |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
 | amazoncorretto-19             |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    |        | ✔️   |     |
-| amazoncorretto-19-debian-slim |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
+| amazoncorretto-19-debian      |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
 | amazoncorretto-20             |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    |        | ✔️   |     |
-| amazoncorretto-20-debian-slim |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
+| amazoncorretto-20-debian      |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
 | azulzulu-11                   |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |
 | azulzulu-11-alpine            |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |
 | azulzulu-17                   |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |

--- a/amazoncorretto-11-debian/Dockerfile
+++ b/amazoncorretto-11-debian/Dockerfile
@@ -1,5 +1,5 @@
-ARG EXTRA_TAG_SUFFIXES=bullseye
-
+# Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
+# EXTRA_TAG_SUFFIXES=bullseye
 FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.

--- a/amazoncorretto-11-debian/Dockerfile
+++ b/amazoncorretto-11-debian/Dockerfile
@@ -1,3 +1,5 @@
+ARG EXTRA_TAG_SUFFIXES=bullseye
+
 FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.

--- a/amazoncorretto-11-debian/Dockerfile
+++ b/amazoncorretto-11-debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.
 RUN apt-get update \
@@ -11,7 +11,7 @@ RUN apt-get update \
   && echo "deb [signed-by=/usr/share/keyrings/corretto.gpg] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
   && apt-get update \
   && apt-get remove --purge --autoremove -y curl gnupg \
-  && apt-get install -y java-1.8.0-amazon-corretto-jdk \
+  && apt-get install -y java-11-amazon-corretto-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images

--- a/amazoncorretto-17-debian/Dockerfile
+++ b/amazoncorretto-17-debian/Dockerfile
@@ -1,5 +1,5 @@
-ARG EXTRA_TAG_SUFFIXES=bullseye
-
+# Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
+# EXTRA_TAG_SUFFIXES=bullseye
 FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.

--- a/amazoncorretto-17-debian/Dockerfile
+++ b/amazoncorretto-17-debian/Dockerfile
@@ -1,3 +1,5 @@
+ARG EXTRA_TAG_SUFFIXES=bullseye
+
 FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.

--- a/amazoncorretto-17-debian/Dockerfile
+++ b/amazoncorretto-17-debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.
 RUN apt-get update \
@@ -11,7 +11,7 @@ RUN apt-get update \
   && echo "deb [signed-by=/usr/share/keyrings/corretto.gpg] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
   && apt-get update \
   && apt-get remove --purge --autoremove -y curl gnupg \
-  && apt-get install -y java-11-amazon-corretto-jdk \
+  && apt-get install -y java-17-amazon-corretto-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images

--- a/amazoncorretto-19-debian/Dockerfile
+++ b/amazoncorretto-19-debian/Dockerfile
@@ -1,5 +1,5 @@
-ARG EXTRA_TAG_SUFFIXES=bullseye
-
+# Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
+# EXTRA_TAG_SUFFIXES=bullseye
 FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.

--- a/amazoncorretto-19-debian/Dockerfile
+++ b/amazoncorretto-19-debian/Dockerfile
@@ -1,3 +1,5 @@
+ARG EXTRA_TAG_SUFFIXES=bullseye
+
 FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.

--- a/amazoncorretto-19-debian/Dockerfile
+++ b/amazoncorretto-19-debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.
 RUN apt-get update \
@@ -11,7 +11,7 @@ RUN apt-get update \
   && echo "deb [signed-by=/usr/share/keyrings/corretto.gpg] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
   && apt-get update \
   && apt-get remove --purge --autoremove -y curl gnupg \
-  && apt-get install -y java-17-amazon-corretto-jdk \
+  && apt-get install -y java-19-amazon-corretto-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images

--- a/amazoncorretto-20-debian/Dockerfile
+++ b/amazoncorretto-20-debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.
 RUN apt-get update \

--- a/amazoncorretto-20-debian/Dockerfile
+++ b/amazoncorretto-20-debian/Dockerfile
@@ -1,5 +1,5 @@
-ARG EXTRA_TAG_SUFFIXES=bullseye
-
+# Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
+# EXTRA_TAG_SUFFIXES=bullseye
 FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.

--- a/amazoncorretto-20-debian/Dockerfile
+++ b/amazoncorretto-20-debian/Dockerfile
@@ -1,3 +1,5 @@
+ARG EXTRA_TAG_SUFFIXES=bullseye
+
 FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.

--- a/amazoncorretto-8-debian/Dockerfile
+++ b/amazoncorretto-8-debian/Dockerfile
@@ -1,5 +1,5 @@
-ARG EXTRA_TAG_SUFFIXES=bullseye
-
+# Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
+# EXTRA_TAG_SUFFIXES=bullseye
 FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.

--- a/amazoncorretto-8-debian/Dockerfile
+++ b/amazoncorretto-8-debian/Dockerfile
@@ -1,3 +1,5 @@
+ARG EXTRA_TAG_SUFFIXES=bullseye
+
 FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.

--- a/amazoncorretto-8-debian/Dockerfile
+++ b/amazoncorretto-8-debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 
 # install corretto after verifying that the key is the one we expect.
 RUN apt-get update \
@@ -11,7 +11,7 @@ RUN apt-get update \
   && echo "deb [signed-by=/usr/share/keyrings/corretto.gpg] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
   && apt-get update \
   && apt-get remove --purge --autoremove -y curl gnupg \
-  && apt-get install -y java-19-amazon-corretto-jdk \
+  && apt-get install -y java-1.8.0-amazon-corretto-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images

--- a/common.sh
+++ b/common.sh
@@ -44,7 +44,7 @@ version-aliases() {
 	mavenVersion="$(grep -m1 'ARG MAVEN_VERSION=' "$version/Dockerfile" | cut -d'=' -f2)"
 
 	extraSuffixes=()
-	extraSuffixesString="$(grep -m1 'ARG EXTRA_TAG_SUFFIXES=' "$version/Dockerfile" | cut -d'=' -f2)"
+	extraSuffixesString="$(grep -m1 '# EXTRA_TAG_SUFFIXES=' "$version/Dockerfile" | cut -d'=' -f2)"
 	if [ -n "${extraSuffixesString}" ]; then
 		for suffix in ${extraSuffixesString//,/ }; do
 			extraSuffixes+=("${suffix}")

--- a/common.sh
+++ b/common.sh
@@ -43,6 +43,14 @@ version-aliases() {
 
 	mavenVersion="$(grep -m1 'ARG MAVEN_VERSION=' "$version/Dockerfile" | cut -d'=' -f2)"
 
+	extraSuffixes=()
+	extraSuffixesString="$(grep -m1 'ARG EXTRA_TAG_SUFFIXES=' "$version/Dockerfile" | cut -d'=' -f2)"
+	if [ -n "${extraSuffixesString}" ]; then
+		for suffix in ${extraSuffixesString//,/ }; do
+			extraSuffixes+=("${suffix}")
+		done
+	fi
+
 	versionAliases=()
 	while [ "${mavenVersion%[.-]*}" != "$mavenVersion" ]; do
 		versionAliases+=("$mavenVersion-$version")
@@ -63,11 +71,18 @@ version-aliases() {
 			versionAliases+=("$mavenVersion-${extra_tags[$version]}")
 		fi
 
+		for extraSuffix in "${extraSuffixes[@]}"; do
+			versionAliases+=("${mavenVersion}-${version}-${extraSuffix}")
+		done
+
 		mavenVersion="${mavenVersion%[.-]*}"
 	done
 
 	# tag full version
 	versionAliases+=("$mavenVersion-$version")
+	for extraSuffix in "${extraSuffixes[@]}"; do
+		versionAliases+=("${mavenVersion}-${version}-${extraSuffix}")
+	done
 
 	# tag 3, latest
 	if [[ "$version" == "$default_jdk-$latest" ]]; then

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -40,6 +40,13 @@ generate-version() {
 	arches="${arches//arm32v5, /}"
 	arches="${arches//mips64le, /}"
 
+	# Amazon Corretto apt does not support arm32v7, ppc64le, s390x
+	if [[ "${version}" == amazoncorretto-*-debian ]]; then
+		arches="${arches//arm32v7, /}"
+		arches="${arches//ppc64le, /}"
+		arches="${arches//s390x, /}"
+	fi
+
 	echo
 	echo "Tags: $(join ', ' "${versionAliases[@]}")"
 	echo "Architectures: $arches"
@@ -63,8 +70,7 @@ for version in "${all_dirs[@]}"; do
 	if grep -q "FROM .*windows" "$version/Dockerfile"; then
 		continue
 	fi
-	# also ignore corretto debian-slim for now
-	if [[ "$version" != azulzulu* ]] && [[ "$version" != liberica* ]] && [[ "$version" != amazoncorretto-*-debian-slim ]]; then
+	if [[ "$version" != azulzulu* ]] && [[ "$version" != liberica* ]]; then
 		branch=main
 		mapfile -t versionAliases < <(version-aliases "$version" "$branch")
 		generate-version "$version" "$branch" "${versionAliases[@]}"

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -80,7 +80,7 @@ load test_helpers
 
 @test "$SUT_TAG curl is installed" {
 	run docker run --rm $SUT_IMAGE:$SUT_TAG curl --version
-	if [[ "$SUT_TAG" == amazoncorretto-*-debian-slim ]]; then
+	if [[ "$SUT_TAG" == amazoncorretto-*-debian ]]; then
 		assert_failure
 	else
 		assert_success


### PR DESCRIPTION
I've done the following in this PR:
- renamed `amazoncorretto-*-debian-slim` to just `amazoncorretto-*-debian`
- added way to specify extra tag suffixes for an image in Dockerfile via an ARG
  - added tagging corretto debian variants with `bullseye` suffix so one can pin to that to guard against surprise upgrade to next stable
- pruned arches not supported by corretto apt repo

Let me know what you think of all this; of course, I'm happy to make any changes you suggest.