### PR TITLE
Remove s390x for amazoncorretto-*-debian actually

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -44,7 +44,7 @@ generate-version() {
 	if [[ "${version}" == amazoncorretto-*-debian ]]; then
 		arches="${arches//arm32v7, /}"
 		arches="${arches//ppc64le, /}"
-		arches="${arches//s390x, /}"
+		arches="${arches//s390x/}"
 	fi
 
 	echo


### PR DESCRIPTION
@carlossg can you see if this works for the moment? Unfortunately, my current dev env is not set up properly to run `generate_stackbrew_library.sh` 😔.

I can try to make a cleaner fix later that doesn't assume the order of the architectures (probably something like put them in a bash array, loop through them and only take what we need).