### PR TITLE
Debian stable has rolled from version 11 (bullseye) to 12 (bookworm).…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ See Docker Hub or GitHub Container Registry for an updated list of tags
 * [amazoncorretto-16](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-16/)
 * [amazoncorretto-17](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-17/)
 * [amazoncorretto-20](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-20/)
+* [amazoncorretto-8-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-8-debian/Dockerfile)
+* [amazoncorretto-11-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-11-debian/Dockerfile)
+* [amazoncorretto-17-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-17-debian/Dockerfile)
+* [amazoncorretto-20-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-20-debian/Dockerfile)
 * [sapmachine-11](https://github.com/carlossg/docker-maven/blob/main/sapmachine-11/)
 * [sapmachine-17](https://github.com/carlossg/docker-maven/blob/main/sapmachine-17/)
 
@@ -60,10 +64,6 @@ Only under `csanchez/maven` and `ghcr.io/carlossg/maven`:
 * [microsoft-openjdk-11-ubuntu](https://github.com/carlossg/docker-maven/blob/main/microsoft-openjdk-11-ubuntu/Dockerfile)
 * [microsoft-openjdk-16-ubuntu](https://github.com/carlossg/docker-maven/blob/main/microsoft-openjdk-16-ubuntu/Dockerfile)
 * [microsoft-openjdk-17-ubuntu](https://github.com/carlossg/docker-maven/blob/main/microsoft-openjdk-17-ubuntu/Dockerfile)
-* [amazoncorretto-8-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-8-debian/Dockerfile)
-* [amazoncorretto-11-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-11-debian/Dockerfile)
-* [amazoncorretto-17-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-17-debian/Dockerfile)
-* [amazoncorretto-20-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-20-debian/Dockerfile)
 
 ## Windows Based Images
 

--- a/amazoncorretto-11-debian/Dockerfile
+++ b/amazoncorretto-11-debian/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bullseye
-FROM debian:bullseye-slim
+# EXTRA_TAG_SUFFIXES=bookworm
+FROM debian:bookworm-slim
 
 # install corretto after verifying that the key is the one we expect.
 RUN apt-get update \

--- a/amazoncorretto-17-debian/Dockerfile
+++ b/amazoncorretto-17-debian/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bullseye
-FROM debian:bullseye-slim
+# EXTRA_TAG_SUFFIXES=bookworm
+FROM debian:bookworm-slim
 
 # install corretto after verifying that the key is the one we expect.
 RUN apt-get update \

--- a/amazoncorretto-20-debian/Dockerfile
+++ b/amazoncorretto-20-debian/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bullseye
-FROM debian:bullseye-slim
+# EXTRA_TAG_SUFFIXES=bookworm
+FROM debian:bookworm-slim
 
 # install corretto after verifying that the key is the one we expect.
 RUN apt-get update \

--- a/amazoncorretto-8-debian/Dockerfile
+++ b/amazoncorretto-8-debian/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bullseye
-FROM debian:bullseye-slim
+# EXTRA_TAG_SUFFIXES=bookworm
+FROM debian:bookworm-slim
 
 # install corretto after verifying that the key is the one we expect.
 RUN apt-get update \


### PR DESCRIPTION
… Moving amazoncorretto-debian images to bookworm

Also moved the amazoncorretto-*-debian images to be listed in README under Docker Hub section.

Reference -- https://www.debian.org/releases/ shows that ` The current "stable" distribution of Debian is version 12, codenamed bookworm. It was released on June 10th, 2023. `