### PR TITLE
Add Amazon Corretto 21 image

### DIFF
--- a/.github/workflows/amazoncorretto-21.yml
+++ b/.github/workflows/amazoncorretto-21.yml
@@ -1,0 +1,32 @@
+name: amazoncorretto-21
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - "amazoncorretto-21/**"
+      - .github/workflows/amazoncorretto-21.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+  pull_request:
+    paths:
+      - "amazoncorretto-21/**"
+      - .github/workflows/amazoncorretto-21.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+
+jobs:
+  build:
+    uses: ./.github/workflows/_template.yml
+    with:
+      directory: amazoncorretto-21
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See Docker Hub or GitHub Container Registry for an updated list of tags
 * [amazoncorretto-20](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-20/)
 * [amazoncorretto-20-al2023](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-20-al2023/Dockerfile)
 * [amazoncorretto-20-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-20-debian/Dockerfile)
+* [amazoncorretto-21](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-21/)
 * [amazoncorretto-21-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-21-debian/Dockerfile)
 * [sapmachine-11](https://github.com/carlossg/docker-maven/blob/main/sapmachine-11/)
 * [sapmachine-17](https://github.com/carlossg/docker-maven/blob/main/sapmachine-17/)
@@ -212,6 +213,7 @@ Some come from the parent images and some are installed in this image for backwa
 | amazoncorretto-20             |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    |        | ✔️   |     |
 | amazoncorretto-20-al2023      |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    |        | ✔️   |     |
 | amazoncorretto-20-debian      |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
+| amazoncorretto-21             |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    |        | ✔️   |     |
 | amazoncorretto-21-debian      |     |      | ✔️   | ✔️    | ✔️     | ✔️    |        |     |     |
 | azulzulu-11                   |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |
 | azulzulu-11-alpine            |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |

--- a/amazoncorretto-21/Dockerfile
+++ b/amazoncorretto-21/Dockerfile
@@ -1,0 +1,19 @@
+FROM amazoncorretto:21
+
+RUN yum install -y tar which gzip # TODO remove
+
+# common for all images
+ENV MAVEN_HOME /usr/share/maven
+
+COPY --from=maven:3.9.4-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.4-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.4-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=3.9.4
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]


### PR DESCRIPTION
Since Amazon Corretto team published new images based on Java 21 (https://github.com/corretto/corretto-docker/pull/179 ), this PR introduces similar amazoncorreto-21 flavour as there already is for older Java versions.

I looked also at the al2023 variant, but there are no `generic` corretto images, so while it could be done using `headless`, I'm not sure whether that's desirable.

Let me know if anything is missing from this PR. Thanks