### PR TITLE
test: lock bats version to 1.10.0

### DIFF
--- a/.github/workflows/_template.yml
+++ b/.github/workflows/_template.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup BATS
         uses: bats-core/bats-action@1.5.6
+        with:
+          bats-version: 1.10.0
       - name: Update submodules
         run: git submodule update --init
 

--- a/README.md
+++ b/README.md
@@ -240,8 +240,10 @@ Some come from the parent images and some are installed in this image for backwa
 | eclipse-temurin-17-focal      | ✔️   | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |
 | eclipse-temurin-21            | ✔️   | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |
 | eclipse-temurin-21-alpine     |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |
+| eclipse-temurin-22-jammy      | ✔️   | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |
 | eclipse-temurin-22            | ✔️   | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |
 | eclipse-temurin-22-alpine     |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |
+| eclipse-temurin-22-jammy      | ✔️   | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |
 | graalvm-community-17          |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    |        | ✔️   |     |
 | graalvm-community-21          |     | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    |        | ✔️   |     |
 | ibm-semeru-11-focal           | ✔️   | ✔️    | ✔️   | ✔️    | ✔️     | ✔️    | ✔️      |     |     |


### PR DESCRIPTION
as 1.11 breaks bats-action

https://github.com/bats-core/bats-action/pull/4