### PR TITLE
set default user to non-root

### DIFF
--- a/Dockerfile-template
+++ b/Dockerfile-template
@@ -5,11 +5,15 @@ COPY --from=maven:3.9.6-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.6-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
 COPY --from=maven:3.9.6-eclipse-temurin-11 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
 
-RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn \
+	&& mkdir /src \
+	&& chown 1000 /src
 
 ARG MAVEN_VERSION=3.9.6
-ARG USER_HOME_DIR="/root"
+ARG USER_HOME_DIR="/src"
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]
+
+USER 1000


### PR DESCRIPTION
Runs the container as user different from root for security reasons.

See https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user