### PR TITLE
style: update the use of LegacyKeyValueFormat in Dockerfiles

### DIFF
--- a/Dockerfile-template
+++ b/Dockerfile-template
@@ -1,10 +1,10 @@
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -14,7 +14,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-11-al2023/Dockerfile
+++ b/amazoncorretto-11-al2023/Dockerfile
@@ -4,12 +4,12 @@ RUN yum install -y tar which gzip findutils # TODO remove
 RUN yum install -y openssh-clients
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -19,7 +19,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-11-debian/Dockerfile
+++ b/amazoncorretto-11-debian/Dockerfile
@@ -17,15 +17,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # set JAVA_HOME manually since nothing else will set it
-ENV JAVA_HOME "/usr/lib/jvm/java-11-amazon-corretto"
+ENV JAVA_HOME="/usr/lib/jvm/java-11-amazon-corretto"
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -35,7 +35,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-11-windowsservercore/Dockerfile
+++ b/amazoncorretto-11-windowsservercore/Dockerfile
@@ -1,10 +1,10 @@
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -31,8 +31,8 @@ RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin
   New-Item -ItemType Directory -Path C:/ProgramData/Maven/Reference | Out-Null ; `
   Remove-Item ${env:TEMP}/apache-maven.zip
 
-ENV MAVEN_HOME C:/ProgramData/Maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_HOME=C:/ProgramData/Maven
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 COPY mvn-entrypoint.ps1 C:/ProgramData/Maven/mvn-entrypoint.ps1
 COPY settings-docker.xml C:/ProgramData/Maven/Reference/settings-docker.xml

--- a/amazoncorretto-11/Dockerfile
+++ b/amazoncorretto-11/Dockerfile
@@ -4,12 +4,12 @@ RUN yum install -y tar which gzip # TODO remove
 RUN yum install -y openssh-clients
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -19,7 +19,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-17-al2023/Dockerfile
+++ b/amazoncorretto-17-al2023/Dockerfile
@@ -4,12 +4,12 @@ RUN yum install -y tar which gzip findutils # TODO remove
 RUN yum install -y openssh-clients
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -19,7 +19,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-17-debian/Dockerfile
+++ b/amazoncorretto-17-debian/Dockerfile
@@ -17,15 +17,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # set JAVA_HOME manually since nothing else will set it
-ENV JAVA_HOME "/usr/lib/jvm/java-17-amazon-corretto"
+ENV JAVA_HOME="/usr/lib/jvm/java-17-amazon-corretto"
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -35,7 +35,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-17-windowsservercore/Dockerfile
+++ b/amazoncorretto-17-windowsservercore/Dockerfile
@@ -1,10 +1,10 @@
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -31,8 +31,8 @@ RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin
   New-Item -ItemType Directory -Path C:/ProgramData/Maven/Reference | Out-Null ; `
   Remove-Item ${env:TEMP}/apache-maven.zip
 
-ENV MAVEN_HOME C:/ProgramData/Maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_HOME=C:/ProgramData/Maven
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 COPY mvn-entrypoint.ps1 C:/ProgramData/Maven/mvn-entrypoint.ps1
 COPY settings-docker.xml C:/ProgramData/Maven/Reference/settings-docker.xml

--- a/amazoncorretto-17/Dockerfile
+++ b/amazoncorretto-17/Dockerfile
@@ -4,12 +4,12 @@ RUN yum install -y tar which gzip # TODO remove
 RUN yum install -y openssh-clients
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -19,7 +19,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-21-al2023/Dockerfile
+++ b/amazoncorretto-21-al2023/Dockerfile
@@ -4,12 +4,12 @@ RUN yum install -y tar which gzip findutils # TODO remove
 RUN yum install -y openssh-clients
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -19,7 +19,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-21-debian/Dockerfile
+++ b/amazoncorretto-21-debian/Dockerfile
@@ -17,15 +17,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # set JAVA_HOME manually since nothing else will set it
-ENV JAVA_HOME "/usr/lib/jvm/java-21-amazon-corretto"
+ENV JAVA_HOME="/usr/lib/jvm/java-21-amazon-corretto"
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -35,7 +35,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-21/Dockerfile
+++ b/amazoncorretto-21/Dockerfile
@@ -4,12 +4,12 @@ RUN yum install -y tar which gzip # TODO remove
 RUN yum install -y openssh-clients
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -19,7 +19,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-8-al2023/Dockerfile
+++ b/amazoncorretto-8-al2023/Dockerfile
@@ -4,12 +4,12 @@ RUN yum install -y tar which gzip findutils # TODO remove
 RUN yum install -y openssh-clients
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -19,7 +19,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-8-debian/Dockerfile
+++ b/amazoncorretto-8-debian/Dockerfile
@@ -17,15 +17,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # set JAVA_HOME manually since nothing else will set it
-ENV JAVA_HOME "/usr/lib/jvm/java-1.8.0-amazon-corretto/jre"
+ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-amazon-corretto/jre"
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -35,7 +35,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-8-windowsservercore/Dockerfile
+++ b/amazoncorretto-8-windowsservercore/Dockerfile
@@ -1,10 +1,10 @@
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -31,8 +31,8 @@ RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin
   New-Item -ItemType Directory -Path C:/ProgramData/Maven/Reference | Out-Null ; `
   Remove-Item ${env:TEMP}/apache-maven.zip
 
-ENV MAVEN_HOME C:/ProgramData/Maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_HOME=C:/ProgramData/Maven
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 COPY mvn-entrypoint.ps1 C:/ProgramData/Maven/mvn-entrypoint.ps1
 COPY settings-docker.xml C:/ProgramData/Maven/Reference/settings-docker.xml

--- a/amazoncorretto-8/Dockerfile
+++ b/amazoncorretto-8/Dockerfile
@@ -4,12 +4,12 @@ RUN yum install -y tar which gzip # TODO remove
 RUN yum install -y openssh-clients
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -19,7 +19,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-11-alpine/Dockerfile
+++ b/azulzulu-11-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM azul/zulu-openjdk-alpine:11
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-11-windowsservercore/Dockerfile
+++ b/azulzulu-11-windowsservercore/Dockerfile
@@ -1,10 +1,10 @@
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -29,8 +29,8 @@ RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin
   New-Item -ItemType Directory -Path C:/ProgramData/Maven/Reference | Out-Null ; `
   Remove-Item ${env:TEMP}/apache-maven.zip
 
-ENV MAVEN_HOME C:/ProgramData/Maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_HOME=C:/ProgramData/Maven
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENV JAVA_HOME=C:/ProgramData/zulu11.37.17-ca-jdk11.0.6-win_x64
 

--- a/azulzulu-11/Dockerfile
+++ b/azulzulu-11/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-17-alpine/Dockerfile
+++ b/azulzulu-17-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM azul/zulu-openjdk-alpine:17
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-17-windowsservercore/Dockerfile
+++ b/azulzulu-17-windowsservercore/Dockerfile
@@ -1,10 +1,10 @@
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -29,8 +29,8 @@ RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin
   New-Item -ItemType Directory -Path C:/ProgramData/Maven/Reference | Out-Null ; `
   Remove-Item ${env:TEMP}/apache-maven.zip
 
-ENV MAVEN_HOME C:/ProgramData/Maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_HOME=C:/ProgramData/Maven
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENV JAVA_HOME=C:/ProgramData/zulu17.48.15-ca-jdk17.0.10-win_x64
 

--- a/azulzulu-17/Dockerfile
+++ b/azulzulu-17/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-21-alpine/Dockerfile
+++ b/azulzulu-21-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM azul/zulu-openjdk-alpine:21
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-21/Dockerfile
+++ b/azulzulu-21/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-8-alpine/Dockerfile
+++ b/azulzulu-8-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM azul/zulu-openjdk-alpine:8
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-8/Dockerfile
+++ b/azulzulu-8/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-11-alpine/Dockerfile
+++ b/eclipse-temurin-11-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM eclipse-temurin:11-jdk-alpine
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-11-focal/Dockerfile
+++ b/eclipse-temurin-11-focal/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-11/Dockerfile
+++ b/eclipse-temurin-11/Dockerfile
@@ -5,8 +5,8 @@ ARG USER_HOME_DIR="/root"
 ARG SHA=7d171def9b85846bf757a2cec94b7529371068a0670df14682447224e57983528e97a6d1b850327e4ca02b139abaab7fcb93c4315119e6f0ffb3f0cbc0d0b9a2
 ARG BASE_URL=https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_HOME=/usr/share/maven
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 RUN apt-get update \
   && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
@@ -36,12 +36,12 @@ RUN apt-get update \
   && apt-get install -y ca-certificates curl git openssh-client --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=builder ${MAVEN_HOME} ${MAVEN_HOME}
 COPY mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -51,7 +51,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-17-alpine/Dockerfile
+++ b/eclipse-temurin-17-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM eclipse-temurin:17-jdk-alpine
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-17-focal/Dockerfile
+++ b/eclipse-temurin-17-focal/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-17/Dockerfile
+++ b/eclipse-temurin-17/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-21-alpine/Dockerfile
+++ b/eclipse-temurin-21-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM eclipse-temurin:21-jdk-alpine
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-21-jammy/Dockerfile
+++ b/eclipse-temurin-21-jammy/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-21/Dockerfile
+++ b/eclipse-temurin-21/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-22-alpine/Dockerfile
+++ b/eclipse-temurin-22-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM eclipse-temurin:22-jdk-alpine
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-22-jammy/Dockerfile
+++ b/eclipse-temurin-22-jammy/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-22/Dockerfile
+++ b/eclipse-temurin-22/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-8-alpine/Dockerfile
+++ b/eclipse-temurin-8-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM eclipse-temurin:8-jdk-alpine
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-8-focal/Dockerfile
+++ b/eclipse-temurin-8-focal/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-8/Dockerfile
+++ b/eclipse-temurin-8/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/graalvm-community-17/Dockerfile
+++ b/graalvm-community-17/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
 LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
 LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -17,7 +17,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/graalvm-community-21/Dockerfile
+++ b/graalvm-community-21/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
 LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
 LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibm-semeru-11-focal/Dockerfile
+++ b/ibm-semeru-11-focal/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibm-semeru-17-focal/Dockerfile
+++ b/ibm-semeru-17-focal/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibm-semeru-21-jammy/Dockerfile
+++ b/ibm-semeru-21-jammy/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibmjava-8/Dockerfile
+++ b/ibmjava-8/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-11-alpine/Dockerfile
+++ b/libericaopenjdk-11-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM bellsoft/liberica-openjdk-alpine:11
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-11-debian/Dockerfile
+++ b/libericaopenjdk-11-debian/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-17-alpine/Dockerfile
+++ b/libericaopenjdk-17-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM bellsoft/liberica-openjdk-alpine:17
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-17-debian/Dockerfile
+++ b/libericaopenjdk-17-debian/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-8-alpine/Dockerfile
+++ b/libericaopenjdk-8-alpine/Dockerfile
@@ -3,12 +3,12 @@ FROM bellsoft/liberica-openjdk-alpine:8
 RUN apk add --no-cache bash procps curl tar openssh-client
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-8-debian/Dockerfile
+++ b/libericaopenjdk-8-debian/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-11-ubuntu/Dockerfile
+++ b/microsoft-openjdk-11-ubuntu/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-17-ubuntu/Dockerfile
+++ b/microsoft-openjdk-17-ubuntu/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-21-ubuntu/Dockerfile
+++ b/microsoft-openjdk-21-ubuntu/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/openjdk-11-nanoserver/Dockerfile
+++ b/openjdk-11-nanoserver/Dockerfile
@@ -7,10 +7,10 @@ FROM openjdk:${JAVA_VERSION}-windowsservercore-1809 as openjdk
 
 FROM mcr.microsoft.com/powershell:${POWERSHELL_VERSION}nanoserver-1809 
 
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -35,8 +35,8 @@ RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin
   New-Item -ItemType Directory -Path C:/ProgramData/Maven/Reference | Out-Null ; `
   Remove-Item ${env:TEMP}/apache-maven.zip
 
-ENV MAVEN_HOME C:/ProgramData/Maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_HOME=C:/ProgramData/Maven
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 COPY mvn-entrypoint.ps1 C:/ProgramData/Maven/mvn-entrypoint.ps1
 COPY settings-docker.xml C:/ProgramData/Maven/Reference/settings-docker.xml

--- a/openjdk-11-windowsservercore/Dockerfile
+++ b/openjdk-11-windowsservercore/Dockerfile
@@ -1,10 +1,10 @@
 # escape=`
 FROM openjdk:11-jdk-windowsservercore-1809
 
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,8 +20,8 @@ RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin
   New-Item -ItemType Directory -Path C:/ProgramData/Maven/Reference | Out-Null ; `
   Remove-Item ${env:TEMP}/apache-maven.zip
 
-ENV MAVEN_HOME C:/ProgramData/Maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_HOME=C:/ProgramData/Maven
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 COPY mvn-entrypoint.ps1 C:/ProgramData/Maven/mvn-entrypoint.ps1
 COPY settings-docker.xml C:/ProgramData/Maven/Reference/settings-docker.xml

--- a/openjdk-8-nanoserver/Dockerfile
+++ b/openjdk-8-nanoserver/Dockerfile
@@ -7,10 +7,10 @@ FROM openjdk:${JAVA_VERSION}-windowsservercore-1809 as openjdk
 
 FROM mcr.microsoft.com/powershell:${POWERSHELL_VERSION}nanoserver-1809 
 
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -35,8 +35,8 @@ RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin
   New-Item -ItemType Directory -Path C:/ProgramData/Maven/Reference | Out-Null ; `
   Remove-Item ${env:TEMP}/apache-maven.zip
 
-ENV MAVEN_HOME C:/ProgramData/Maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_HOME=C:/ProgramData/Maven
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 COPY mvn-entrypoint.ps1 C:/ProgramData/Maven/mvn-entrypoint.ps1
 COPY settings-docker.xml C:/ProgramData/Maven/Reference/settings-docker.xml

--- a/openjdk-8-windowsservercore/Dockerfile
+++ b/openjdk-8-windowsservercore/Dockerfile
@@ -1,10 +1,10 @@
 # escape=`
 FROM openjdk:8-jdk-windowsservercore-1809
 
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -20,8 +20,8 @@ RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin
   New-Item -ItemType Directory -Path C:/ProgramData/Maven/Reference | Out-Null ; `
   Remove-Item ${env:TEMP}/apache-maven.zip
 
-ENV MAVEN_HOME C:/ProgramData/Maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_HOME=C:/ProgramData/Maven
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 COPY mvn-entrypoint.ps1 C:/ProgramData/Maven/mvn-entrypoint.ps1
 COPY settings-docker.xml C:/ProgramData/Maven/Reference/settings-docker.xml

--- a/oracle-graalvm-17/Dockerfile
+++ b/oracle-graalvm-17/Dockerfile
@@ -3,12 +3,12 @@ FROM container-registry.oracle.com/graalvm/native-image:17
 RUN microdnf --refresh -y install findutils openssh-clients
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/oracle-graalvm-21/Dockerfile
+++ b/oracle-graalvm-21/Dockerfile
@@ -3,12 +3,12 @@ FROM container-registry.oracle.com/graalvm/native-image:21
 RUN microdnf --refresh -y install findutils openssh-clients
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -18,7 +18,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-11/Dockerfile
+++ b/sapmachine-11/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-17/Dockerfile
+++ b/sapmachine-17/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-21/Dockerfile
+++ b/sapmachine-21/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-22/Dockerfile
+++ b/sapmachine-22/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # common for all images
-LABEL org.opencontainers.image.title "Apache Maven"
-LABEL org.opencontainers.image.source https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.url https://github.com/carlossg/docker-maven
-LABEL org.opencontainers.image.description "Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
 
-ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_HOME=/usr/share/maven
 
 COPY --from=maven:3.9.8-eclipse-temurin-11 ${MAVEN_HOME} ${MAVEN_HOME}
 COPY --from=maven:3.9.8-eclipse-temurin-11 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
@@ -20,7 +20,7 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG MAVEN_VERSION=3.9.8
 ARG USER_HOME_DIR="/root"
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]


### PR DESCRIPTION
Per Docker [build-checks](https://docs.docker.com/reference/build-checks/legacy-key-value-format/):

  The correct format for declaring environment variables and build arguments in a Dockerfile is
  `ENV key=value` and `ARG key=value`, where the variable name (`key`) and value (`value`) are
  separated by an equals sign (`=`). Historically, Dockerfiles have also supported a space
  separator between the key and the value (for example, `ARG key value`). This legacy format is
  deprecated, and you should only use the format with the equals sign.

This admonition does not mention `LABEL`, but it is included.

Update the use of `LABEL` and `ENV` where necessary to remove deprecation warning.

Fixes #486