### PR TITLE
Add Dockerfiles for alpine-based images

### DIFF
--- a/.github/workflows/amazoncorretto-11-alpine.yml
+++ b/.github/workflows/amazoncorretto-11-alpine.yml
@@ -1,0 +1,32 @@
+name: amazoncorretto-11-alpine
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - "amazoncorretto-11-alpine/**"
+      - .github/workflows/amazoncorretto-11-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+  pull_request:
+    paths:
+      - "amazoncorretto-11-alpine/**"
+      - .github/workflows/amazoncorretto-11-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+
+jobs:
+  build:
+    uses: ./.github/workflows/_template.yml
+    with:
+      directory: amazoncorretto-11-alpine
+    secrets: inherit

--- a/.github/workflows/amazoncorretto-17-alpine.yml
+++ b/.github/workflows/amazoncorretto-17-alpine.yml
@@ -1,0 +1,32 @@
+name: amazoncorretto-17-alpine
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - "amazoncorretto-17-alpine/**"
+      - .github/workflows/amazoncorretto-17-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+  pull_request:
+    paths:
+      - "amazoncorretto-17-alpine/**"
+      - .github/workflows/amazoncorretto-17-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+
+jobs:
+  build:
+    uses: ./.github/workflows/_template.yml
+    with:
+      directory: amazoncorretto-17-alpine
+    secrets: inherit

--- a/.github/workflows/amazoncorretto-21-alpine.yml
+++ b/.github/workflows/amazoncorretto-21-alpine.yml
@@ -1,0 +1,32 @@
+name: amazoncorretto-21-alpine
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - "amazoncorretto-21-alpine/**"
+      - .github/workflows/amazoncorretto-21-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+  pull_request:
+    paths:
+      - "amazoncorretto-21-alpine/**"
+      - .github/workflows/amazoncorretto-21-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+
+jobs:
+  build:
+    uses: ./.github/workflows/_template.yml
+    with:
+      directory: amazoncorretto-21-alpine
+    secrets: inherit

--- a/.github/workflows/amazoncorretto-23-alpine.yml
+++ b/.github/workflows/amazoncorretto-23-alpine.yml
@@ -1,0 +1,32 @@
+name: amazoncorretto-23-alpine
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - "amazoncorretto-23-alpine/**"
+      - .github/workflows/amazoncorretto-23-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+  pull_request:
+    paths:
+      - "amazoncorretto-23-alpine/**"
+      - .github/workflows/amazoncorretto-23-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+
+jobs:
+  build:
+    uses: ./.github/workflows/_template.yml
+    with:
+      directory: amazoncorretto-23-alpine
+    secrets: inherit

--- a/.github/workflows/amazoncorretto-8-alpine.yml
+++ b/.github/workflows/amazoncorretto-8-alpine.yml
@@ -1,0 +1,32 @@
+name: amazoncorretto-8-alpine
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - "amazoncorretto-8-alpine/**"
+      - .github/workflows/amazoncorretto-8-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+  pull_request:
+    paths:
+      - "amazoncorretto-8-alpine/**"
+      - .github/workflows/amazoncorretto-8-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+
+jobs:
+  build:
+    uses: ./.github/workflows/_template.yml
+    with:
+      directory: amazoncorretto-8-alpine
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -35,18 +35,23 @@ See Docker Hub or GitHub Container Registry for an updated list of tags
 * [ibmjava-8](https://github.com/carlossg/docker-maven/blob/main/ibmjava-8/Dockerfile)
 * [amazoncorretto-8](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-8/Dockerfile)
 * [amazoncorretto-8-al2023](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-8-al2023/Dockerfile)
+* [amazoncorretto-8-alpine](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-8-alpine/Dockerfile)
 * [amazoncorretto-8-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-8-debian/Dockerfile)
 * [amazoncorretto-11](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-11/)
 * [amazoncorretto-11-al2023](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-11-al2023/Dockerfile)
+* [amazoncorretto-11-alpine](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-11-alpine/Dockerfile)
 * [amazoncorretto-11-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-11-debian/Dockerfile)
 * [amazoncorretto-17](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-17/)
 * [amazoncorretto-17-al2023](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-17-al2023/Dockerfile)
+* [amazoncorretto-17-alpine](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-17-alpine/Dockerfile)
 * [amazoncorretto-17-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-17-debian/Dockerfile)
 * [amazoncorretto-21](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-21/)
 * [amazoncorretto-21-al2023](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-21-al2023/)
+* [amazoncorretto-21-alpine](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-21-alpine/Dockerfile)
 * [amazoncorretto-21-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-21-debian/Dockerfile)
 * [amazoncorretto-23](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-23/)
-* [amazoncorretto-23-al2023](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-23-al2023/)
+* [amazoncorretto-23-al2023](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-23-al2023/Dockerfile)
+* [amazoncorretto-23-alpine](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-17-alpine/Dockerfile)
 * [amazoncorretto-23-debian](https://github.com/carlossg/docker-maven/blob/main/amazoncorretto-23-debian/Dockerfile)
 * [sapmachine-11](https://github.com/carlossg/docker-maven/blob/main/sapmachine-11/)
 * [sapmachine-17](https://github.com/carlossg/docker-maven/blob/main/sapmachine-17/)
@@ -220,18 +225,23 @@ Some come from the parent images and some are installed in this image for backwa
 |-------------------------------|-----|------|-----|------|-------|------|--------|-----|-----|
 | amazoncorretto-8              |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
 | amazoncorretto-8-al2023       |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-8-alpine       |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
 | amazoncorretto-8-debian       |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
 | amazoncorretto-11             |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
 | amazoncorretto-11-al2023      |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-11-alpine      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
 | amazoncorretto-11-debian      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
 | amazoncorretto-17             |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
 | amazoncorretto-17-al2023      |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-17-alpine      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
 | amazoncorretto-17-debian      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
 | amazoncorretto-21             |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
 | amazoncorretto-21-al2023      |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-21-alpine      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
 | amazoncorretto-21-debian      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
 | amazoncorretto-23             |     | ✔︎    |     | ✔︎    |       | ✔︎    |        | ✔︎   | ✔︎   |
 | amazoncorretto-23-al2023      |     | ✔︎    |     | ✔︎    |       | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-23-alpine      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
 | amazoncorretto-23-debian      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
 | azulzulu-8                    |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
 | azulzulu-8-alpine             |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |

--- a/amazoncorretto-11-alpine/Dockerfile
+++ b/amazoncorretto-11-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazoncorretto:11-alpine
 
-RUN apk add --no-cache bash curl openssh-client
+RUN apk add --no-cache bash openssh-client
 
 # common for all images
 LABEL org.opencontainers.image.title="Apache Maven"

--- a/amazoncorretto-11-alpine/Dockerfile
+++ b/amazoncorretto-11-alpine/Dockerfile
@@ -1,0 +1,24 @@
+FROM amazoncorretto:11-alpine
+
+RUN apk add --no-cache bash curl openssh-client
+
+# common for all images
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+
+ENV MAVEN_HOME=/usr/share/maven
+
+COPY --from=maven:3.9.9-eclipse-temurin-17 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.9-eclipse-temurin-17 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.9-eclipse-temurin-17 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=3.9.9
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/amazoncorretto-17-alpine/Dockerfile
+++ b/amazoncorretto-17-alpine/Dockerfile
@@ -1,0 +1,24 @@
+FROM amazoncorretto:17-alpine
+
+RUN apk add --no-cache bash curl openssh-client
+
+# common for all images
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+
+ENV MAVEN_HOME=/usr/share/maven
+
+COPY --from=maven:3.9.9-eclipse-temurin-17 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.9-eclipse-temurin-17 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.9-eclipse-temurin-17 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=3.9.9
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/amazoncorretto-17-alpine/Dockerfile
+++ b/amazoncorretto-17-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazoncorretto:17-alpine
 
-RUN apk add --no-cache bash curl openssh-client
+RUN apk add --no-cache bash openssh-client
 
 # common for all images
 LABEL org.opencontainers.image.title="Apache Maven"

--- a/amazoncorretto-21-alpine/Dockerfile
+++ b/amazoncorretto-21-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazoncorretto:21-alpine
 
-RUN apk add --no-cache bash curl openssh-client
+RUN apk add --no-cache bash openssh-client
 
 # common for all images
 LABEL org.opencontainers.image.title="Apache Maven"

--- a/amazoncorretto-21-alpine/Dockerfile
+++ b/amazoncorretto-21-alpine/Dockerfile
@@ -1,0 +1,24 @@
+FROM amazoncorretto:21-alpine
+
+RUN apk add --no-cache bash curl openssh-client
+
+# common for all images
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+
+ENV MAVEN_HOME=/usr/share/maven
+
+COPY --from=maven:3.9.9-eclipse-temurin-17 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.9-eclipse-temurin-17 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.9-eclipse-temurin-17 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=3.9.9
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/amazoncorretto-23-alpine/Dockerfile
+++ b/amazoncorretto-23-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazoncorretto:23-alpine
 
-RUN apk add --no-cache bash curl openssh-client
+RUN apk add --no-cache bash openssh-client
 
 # common for all images
 LABEL org.opencontainers.image.title="Apache Maven"

--- a/amazoncorretto-23-alpine/Dockerfile
+++ b/amazoncorretto-23-alpine/Dockerfile
@@ -1,0 +1,24 @@
+FROM amazoncorretto:23-alpine
+
+RUN apk add --no-cache bash curl openssh-client
+
+# common for all images
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+
+ENV MAVEN_HOME=/usr/share/maven
+
+COPY --from=maven:3.9.9-eclipse-temurin-17 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.9-eclipse-temurin-17 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.9-eclipse-temurin-17 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=3.9.9
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/amazoncorretto-8-alpine/Dockerfile
+++ b/amazoncorretto-8-alpine/Dockerfile
@@ -1,0 +1,24 @@
+FROM amazoncorretto:8-alpine
+
+RUN apk add --no-cache bash curl openssh-client
+
+# common for all images
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+
+ENV MAVEN_HOME=/usr/share/maven
+
+COPY --from=maven:3.9.9-eclipse-temurin-17 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.9-eclipse-temurin-17 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.9-eclipse-temurin-17 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=3.9.9
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/amazoncorretto-8-alpine/Dockerfile
+++ b/amazoncorretto-8-alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazoncorretto:8-alpine
 
-RUN apk add --no-cache bash curl openssh-client
+RUN apk add --no-cache bash openssh-client
 
 # common for all images
 LABEL org.opencontainers.image.title="Apache Maven"

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -96,6 +96,7 @@ base_image=eclipse-temurin-17
 
 @test "$SUT_TAG curl is installed" {
 	if [[ "$SUT_TAG" == amazoncorretto-*-debian ]] ||
+		[[ "$SUT_TAG" == amazoncorretto-*-alpine ]] ||
 		[[ "$SUT_TAG" == azulzulu-*-debian ]]; then
 		run -127 docker run --rm $SUT_IMAGE:$SUT_TAG curl --version
 	else


### PR DESCRIPTION
## Change Description

Opening this PR to support Alpine-based Corretto images, based on the associated [upstream Amazon maintained Corretto Alpine images](https://github.com/corretto/corretto-docker).

I added installed packages through apk to match the debian images, however I don't think these should be included and should be left to users to extend the image if they want additional utilities like curl on the image, particularly since it increases the complexity for maintaining this project. If that isn't controversial, I'll happily amend my commit to not add any additional packages.

Closes #269

## Testing

I've tested building all versions of the images, as well as using Maven to build Java projects for Java 8 and 17. Worked as expected for me.


