### PR TITLE
Use closer download link and add `84789D24DF77A32433CE1F079EB80E92EB2135B1` key and update JDKs for windows due to latest download URL

### DIFF
--- a/amazoncorretto-11-windowsservercore/Dockerfile
+++ b/amazoncorretto-11-windowsservercore/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG zip=amazon-corretto-11-x64-windows-jdk.zip
 ARG uri=https://corretto.aws/downloads/latest
-ARG hash=df7caf9863ac38df32a4f6c35eec9a923a8043dfcc23f44b2a02945898d29ff1
+ARG hash=2857a5a5b893287e9f2bc1866b0e2e91c53390cddfe7b4954108b5d50b6a0dae
 
 RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zip ; `
     if((Get-FileHash C:/$env:zip -Algorithm SHA256).Hash.ToLower() -ne $env:hash) { exit 1 } ; `

--- a/amazoncorretto-11-windowsservercore/Dockerfile
+++ b/amazoncorretto-11-windowsservercore/Dockerfile
@@ -17,7 +17,7 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
     Expand-Archive -Path C:/$env:zip -Destination C:/ProgramData ; `
     Remove-Item C:/${env:zip}
 
-ENV JAVA_HOME=C:/ProgramData/jdk11.0.26_4
+ENV JAVA_HOME=C:/ProgramData/jdk11.0.27_6
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.9.9

--- a/amazoncorretto-11-windowsservercore/Dockerfile
+++ b/amazoncorretto-11-windowsservercore/Dockerfile
@@ -22,9 +22,9 @@ ENV JAVA_HOME=C:/ProgramData/jdk11.0.26_4
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.9.9
 ARG SHA=8beac8d11ef208f1e2a8df0682b9448a9a363d2ad13ca74af43705549e72e74c9378823bf689287801cbbfc2f6ea9596201d19ccacfdfb682ee8a2ff4c4418ba
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
-RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `
+RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `
   if((Get-FileHash -Algorithm SHA512 -Path ${env:TEMP}/apache-maven.zip).Hash.ToLower() -ne ${env:SHA}) { exit 1 } ; `
   Expand-Archive -Path ${env:TEMP}/apache-maven.zip -Destination C:/ProgramData ; `
   Move-Item C:/ProgramData/apache-maven-${env:MAVEN_VERSION} C:/ProgramData/Maven ; `

--- a/amazoncorretto-17-windowsservercore-maven-4/Dockerfile
+++ b/amazoncorretto-17-windowsservercore-maven-4/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG zip=amazon-corretto-17-x64-windows-jdk.zip
 ARG uri=https://corretto.aws/downloads/latest
-ARG hash=3f3cb5c5f75978dbc60f806b74331ba4bf5a5afe155b64a83844139684f50531
+ARG hash=dcc796f275bd89ed5fc7a7152e2b960ed250dc1b8b4b38a4684f41b97c0b6981
 
 RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zip ; `
   if((Get-FileHash C:/$env:zip -Algorithm SHA256).Hash.ToLower() -ne $env:hash) { `

--- a/amazoncorretto-17-windowsservercore-maven-4/Dockerfile
+++ b/amazoncorretto-17-windowsservercore-maven-4/Dockerfile
@@ -24,9 +24,9 @@ ENV JAVA_HOME=C:/ProgramData/jdk17.0.14_7
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=4.0.0-rc-2
 ARG SHA=333ff30559cb72ecc4ce40308814cdafc9d85d7311305ca66cb40e560033c939be12e6b55ad1c706de67cbf106640e8fc2f4c3a6d33a3fa4cad783d25a01bac0
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-4/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-4/${MAVEN_VERSION}/binaries
 
-RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `
+RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `
   if((Get-FileHash -Algorithm SHA512 -Path ${env:TEMP}/apache-maven.zip).Hash.ToLower() -ne ${env:SHA}) { exit 1 } ; `
   Expand-Archive -Path ${env:TEMP}/apache-maven.zip -Destination C:/ProgramData ; `
   Move-Item C:/ProgramData/apache-maven-${env:MAVEN_VERSION} C:/ProgramData/Maven ; `

--- a/amazoncorretto-17-windowsservercore-maven-4/Dockerfile
+++ b/amazoncorretto-17-windowsservercore-maven-4/Dockerfile
@@ -19,7 +19,7 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
   Expand-Archive -Path C:/$env:zip -Destination C:/ProgramData ; `
   Remove-Item C:/${env:zip}
 
-ENV JAVA_HOME=C:/ProgramData/jdk17.0.14_7
+ENV JAVA_HOME=C:/ProgramData/jdk17.0.15_6
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=4.0.0-rc-2

--- a/amazoncorretto-17-windowsservercore/Dockerfile
+++ b/amazoncorretto-17-windowsservercore/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG zip=amazon-corretto-17-x64-windows-jdk.zip
 ARG uri=https://corretto.aws/downloads/latest
-ARG hash=3f3cb5c5f75978dbc60f806b74331ba4bf5a5afe155b64a83844139684f50531
+ARG hash=dcc796f275bd89ed5fc7a7152e2b960ed250dc1b8b4b38a4684f41b97c0b6981
 
 RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zip ; `
     if((Get-FileHash C:/$env:zip -Algorithm SHA256).Hash.ToLower() -ne $env:hash) { exit 1 } ; `

--- a/amazoncorretto-17-windowsservercore/Dockerfile
+++ b/amazoncorretto-17-windowsservercore/Dockerfile
@@ -22,9 +22,9 @@ ENV JAVA_HOME=C:/ProgramData/jdk17.0.14_7
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.9.9
 ARG SHA=8beac8d11ef208f1e2a8df0682b9448a9a363d2ad13ca74af43705549e72e74c9378823bf689287801cbbfc2f6ea9596201d19ccacfdfb682ee8a2ff4c4418ba
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
-RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `
+RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `
   if((Get-FileHash -Algorithm SHA512 -Path ${env:TEMP}/apache-maven.zip).Hash.ToLower() -ne ${env:SHA}) { exit 1 } ; `
   Expand-Archive -Path ${env:TEMP}/apache-maven.zip -Destination C:/ProgramData ; `
   Move-Item C:/ProgramData/apache-maven-${env:MAVEN_VERSION} C:/ProgramData/Maven ; `

--- a/amazoncorretto-17-windowsservercore/Dockerfile
+++ b/amazoncorretto-17-windowsservercore/Dockerfile
@@ -17,7 +17,7 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
     Expand-Archive -Path C:/$env:zip -Destination C:/ProgramData ; `
     Remove-Item C:/${env:zip}
 
-ENV JAVA_HOME=C:/ProgramData/jdk17.0.14_7
+ENV JAVA_HOME=C:/ProgramData/jdk17.0.15_6
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.9.9

--- a/amazoncorretto-8-windowsservercore/Dockerfile
+++ b/amazoncorretto-8-windowsservercore/Dockerfile
@@ -22,9 +22,9 @@ ENV JAVA_HOME=C:/ProgramData/jdk1.8.0_442
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.9.9
 ARG SHA=8beac8d11ef208f1e2a8df0682b9448a9a363d2ad13ca74af43705549e72e74c9378823bf689287801cbbfc2f6ea9596201d19ccacfdfb682ee8a2ff4c4418ba
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
-RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `
+RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `
   if((Get-FileHash -Algorithm SHA512 -Path ${env:TEMP}/apache-maven.zip).Hash.ToLower() -ne ${env:SHA}) { exit 1 } ; `
   Expand-Archive -Path ${env:TEMP}/apache-maven.zip -Destination C:/ProgramData ; `
   Move-Item C:/ProgramData/apache-maven-${env:MAVEN_VERSION} C:/ProgramData/Maven ; `

--- a/amazoncorretto-8-windowsservercore/Dockerfile
+++ b/amazoncorretto-8-windowsservercore/Dockerfile
@@ -17,7 +17,7 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
     Expand-Archive -Path C:/$env:zip -Destination C:/ProgramData ; `
     Remove-Item C:/${env:zip}
 
-ENV JAVA_HOME=C:/ProgramData/jdk1.8.0_442
+ENV JAVA_HOME=C:/ProgramData/jdk1.8.0_452
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.9.9

--- a/amazoncorretto-8-windowsservercore/Dockerfile
+++ b/amazoncorretto-8-windowsservercore/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG zip=amazon-corretto-8-x64-windows-jdk.zip
 ARG uri=https://corretto.aws/downloads/latest
-ARG hash=63a9e2026978f1e3a1d4bb8175cab0ddfdd5b1030370c1a0d6bb5202924a1dd3
+ARG hash=81aa93761a990de21b0f15df4d289643741f9670af2f97a5a6580a4088748b73
 
 RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zip ; `
     if((Get-FileHash C:/$env:zip -Algorithm SHA256).Hash.ToLower() -ne $env:hash) { exit 1 } ; `

--- a/azulzulu-11-windowsservercore/Dockerfile
+++ b/azulzulu-11-windowsservercore/Dockerfile
@@ -20,9 +20,9 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.9.9
 ARG SHA=8beac8d11ef208f1e2a8df0682b9448a9a363d2ad13ca74af43705549e72e74c9378823bf689287801cbbfc2f6ea9596201d19ccacfdfb682ee8a2ff4c4418ba
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
-RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `
+RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `
   if((Get-FileHash -Algorithm SHA512 -Path ${env:TEMP}/apache-maven.zip).Hash.ToLower() -ne ${env:SHA}) { exit 1 } ; `
   Expand-Archive -Path ${env:TEMP}/apache-maven.zip -Destination C:/ProgramData ; `
   Move-Item C:/ProgramData/apache-maven-${env:MAVEN_VERSION} C:/ProgramData/Maven ; `

--- a/azulzulu-17-windowsservercore-maven-4/Dockerfile
+++ b/azulzulu-17-windowsservercore-maven-4/Dockerfile
@@ -20,9 +20,9 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=4.0.0-rc-2
 ARG SHA=333ff30559cb72ecc4ce40308814cdafc9d85d7311305ca66cb40e560033c939be12e6b55ad1c706de67cbf106640e8fc2f4c3a6d33a3fa4cad783d25a01bac0
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-4/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-4/${MAVEN_VERSION}/binaries
 
-RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `
+RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `
   if((Get-FileHash -Algorithm SHA512 -Path ${env:TEMP}/apache-maven.zip).Hash.ToLower() -ne ${env:SHA}) { exit 1 } ; `
   Expand-Archive -Path ${env:TEMP}/apache-maven.zip -Destination C:/ProgramData ; `
   Move-Item C:/ProgramData/apache-maven-${env:MAVEN_VERSION} C:/ProgramData/Maven ; `

--- a/azulzulu-17-windowsservercore/Dockerfile
+++ b/azulzulu-17-windowsservercore/Dockerfile
@@ -20,9 +20,9 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
 ARG MAVEN_VERSION=3.9.9
 ARG SHA=8beac8d11ef208f1e2a8df0682b9448a9a363d2ad13ca74af43705549e72e74c9378823bf689287801cbbfc2f6ea9596201d19ccacfdfb682ee8a2ff4c4418ba
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
-RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip -OutFile ${env:TEMP}/apache-maven.zip ; `
+RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `
   if((Get-FileHash -Algorithm SHA512 -Path ${env:TEMP}/apache-maven.zip).Hash.ToLower() -ne ${env:SHA}) { exit 1 } ; `
   Expand-Archive -Path ${env:TEMP}/apache-maven.zip -Destination C:/ProgramData ; `
   Move-Item C:/ProgramData/apache-maven-${env:MAVEN_VERSION} C:/ProgramData/Maven ; `

--- a/eclipse-temurin-17-maven-4/Dockerfile
+++ b/eclipse-temurin-17-maven-4/Dockerfile
@@ -20,6 +20,7 @@ RUN set -eux; curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}
   29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
   073F7A9345756F3B40CDB99E6C70A3B7599C5736 \
   88BE34F94BDB2B5357044E2E3A387D43964143E3 \
+  84789D24DF77A32433CE1F079EB80E92EB2135B1 \
   ; do \
   gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
   done; \

--- a/eclipse-temurin-17-maven-4/Dockerfile
+++ b/eclipse-temurin-17-maven-4/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipse-temurin:17-jdk AS builder
 ARG MAVEN_VERSION=4.0.0-rc-2
 ARG USER_HOME_DIR="/root"
 ARG SHA=3875f0387334d1a3941f344f654be30d9687c997faa599d7144f312d0a14d3d23fe35828223f93a57bf2682f8e6e2ad601a9c3dc28a8488acee13d1ad4e53dfe
-ARG BASE_URL=https://dlcdn.apache.org/maven/maven-4/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-4/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME=/usr/share/maven
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
@@ -11,9 +11,9 @@ ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 RUN apt-get update \
   && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
-RUN set -eux; curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+RUN set -eux; curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz?action=download \
   && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc?action=download \
   && export GNUPGHOME="$(mktemp -d)"; \
   for key in \
   6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \

--- a/eclipse-temurin-17/Dockerfile
+++ b/eclipse-temurin-17/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipse-temurin:17-jdk AS builder
 ARG MAVEN_VERSION=3.9.9
 ARG USER_HOME_DIR="/root"
 ARG SHA=a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
-ARG BASE_URL=https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME=/usr/share/maven
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
@@ -11,9 +11,9 @@ ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 RUN apt-get update \
   && apt-get install -y ca-certificates curl git gnupg dirmngr --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
-RUN set -eux; curl -fsSLO --retry 3 --retry-connrefused --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+RUN set -eux; curl -fsSLO --retry 3 --retry-connrefused --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz?action=download \
   && echo "${SHA} *apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
-  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc \
+  && curl -fsSLO --compressed ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz.asc?action=download \
   && export GNUPGHOME="$(mktemp -d)"; \
   for key in \
   6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \

--- a/eclipse-temurin-17/Dockerfile
+++ b/eclipse-temurin-17/Dockerfile
@@ -19,6 +19,7 @@ RUN set -eux; curl -fsSLO --retry 3 --retry-connrefused --compressed ${BASE_URL}
   6A814B1F869C2BBEAB7CB7271A2A1C94BDE89688 \
   29BEA2A645F2D6CED7FB12E02B172E3E156466E8 \
   88BE34F94BDB2B5357044E2E3A387D43964143E3 \
+  84789D24DF77A32433CE1F079EB80E92EB2135B1 \
   ; do \
   gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" ; \
   done; \


### PR DESCRIPTION
@slawekjaranowski 

Probably better to split the upgrade and missing keys

https://github.com/carlossg/docker-maven/pull/551 need to be rebased when merged