### PR TITLE
chore: rolling amazon corretto debian images to target new debian sta…

### DIFF
--- a/amazoncorretto-11-debian/Dockerfile
+++ b/amazoncorretto-11-debian/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bookworm
-FROM debian:bookworm-slim
+# EXTRA_TAG_SUFFIXES=trixie
+FROM debian:trixie-slim
 
 # install corretto after verifying that the key is the one we expect.
 # and keep openssh client

--- a/amazoncorretto-17-debian-maven-4/Dockerfile
+++ b/amazoncorretto-17-debian-maven-4/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bookworm
-FROM debian:bookworm-slim
+# EXTRA_TAG_SUFFIXES=trixie
+FROM debian:trixie-slim
 
 # install corretto after verifying that the key is the one we expect.
 # and keep openssh client

--- a/amazoncorretto-17-debian/Dockerfile
+++ b/amazoncorretto-17-debian/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bookworm
-FROM debian:bookworm-slim
+# EXTRA_TAG_SUFFIXES=trixie
+FROM debian:trixie-slim
 
 # install corretto after verifying that the key is the one we expect.
 # and keep openssh client

--- a/amazoncorretto-21-debian-maven-4/Dockerfile
+++ b/amazoncorretto-21-debian-maven-4/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bookworm
-FROM debian:bookworm-slim
+# EXTRA_TAG_SUFFIXES=trixie
+FROM debian:trixie-slim
 
 # install corretto after verifying that the key is the one we expect.
 # and keep openssh client

--- a/amazoncorretto-21-debian/Dockerfile
+++ b/amazoncorretto-21-debian/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bookworm
-FROM debian:bookworm-slim
+# EXTRA_TAG_SUFFIXES=trixie
+FROM debian:trixie-slim
 
 # install corretto after verifying that the key is the one we expect.
 # and keep openssh client

--- a/amazoncorretto-24-debian-maven-4/Dockerfile
+++ b/amazoncorretto-24-debian-maven-4/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bookworm
-FROM debian:bookworm-slim
+# EXTRA_TAG_SUFFIXES=trixie
+FROM debian:trixie-slim
 
 # install corretto after verifying that the key is the one we expect.
 # and keep openssh client

--- a/amazoncorretto-24-debian/Dockerfile
+++ b/amazoncorretto-24-debian/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bookworm
-FROM debian:bookworm-slim
+# EXTRA_TAG_SUFFIXES=trixie
+FROM debian:trixie-slim
 
 # install corretto after verifying that the key is the one we expect.
 # and keep openssh client

--- a/amazoncorretto-8-debian/Dockerfile
+++ b/amazoncorretto-8-debian/Dockerfile
@@ -1,6 +1,6 @@
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
-# EXTRA_TAG_SUFFIXES=bookworm
-FROM debian:bookworm-slim
+# EXTRA_TAG_SUFFIXES=trixie
+FROM debian:trixie-slim
 
 # install corretto after verifying that the key is the one we expect.
 # and keep openssh client


### PR DESCRIPTION
…ble - trixie

debian stable rolled from bookworm to trixie on august 9 - https://www.debian.org/News/2025/20250809