### PR TITLE
Ignore riscv64 for corretto debian images as corretto does not suppor…

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -54,9 +54,9 @@ generate-version() {
 			continue
 		fi
 
-		# Amazon Corretto apt does not support arm32v7, ppc64le, s390x
+		# Amazon Corretto apt does not support arm32v7, ppc64le, s390x, riscv64
 		if [[ "${version}" == amazoncorretto-*-debian ]]; then
-			if [[ "${arch}" == "arm32v7" ]] || [[ "${arch}" == "ppc64le" ]] || [[ "${arch}" == "s390x" ]]; then
+			if [[ "${arch}" != "amd64" ]] && [[ "${arch}" != "arm64v8" ]]; then
 				continue
 			fi
 		fi


### PR DESCRIPTION
…t riscv64

sorry, I didn't realize trixie added support for riscv64 for the first time -- https://www.debian.org/releases/trixie/release-notes/whats-new.en.html#official-support-for-riscv64

saw the [comment](https://github.com/docker-library/official-images/pull/19726#issuecomment-3201503606) 😅