### PR TITLE
feat: add eclipse-temurin-25 docker images

### DIFF
--- a/.github/workflows/eclipse-temurin-25-alpine-maven-4.yml
+++ b/.github/workflows/eclipse-temurin-25-alpine-maven-4.yml
@@ -1,0 +1,32 @@
+name: eclipse-temurin-25-alpine-maven-4
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - "eclipse-temurin-25-alpine-maven-4/**"
+      - .github/workflows/eclipse-temurin-25-alpine-maven-4.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+  pull_request:
+    paths:
+      - "eclipse-temurin-25-alpine-maven-4/**"
+      - .github/workflows/eclipse-temurin-25-alpine-maven-4.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+
+jobs:
+  build:
+    uses: ./.github/workflows/_template.yml
+    with:
+      directory: eclipse-temurin-25-alpine-maven-4
+    secrets: inherit

--- a/.github/workflows/eclipse-temurin-25-alpine.yml
+++ b/.github/workflows/eclipse-temurin-25-alpine.yml
@@ -1,0 +1,32 @@
+name: eclipse-temurin-25-alpine
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - "eclipse-temurin-25-alpine/**"
+      - .github/workflows/eclipse-temurin-25-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+  pull_request:
+    paths:
+      - "eclipse-temurin-25-alpine/**"
+      - .github/workflows/eclipse-temurin-25-alpine.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+
+jobs:
+  build:
+    uses: ./.github/workflows/_template.yml
+    with:
+      directory: eclipse-temurin-25-alpine
+    secrets: inherit

--- a/.github/workflows/eclipse-temurin-25-noble-maven-4.yml
+++ b/.github/workflows/eclipse-temurin-25-noble-maven-4.yml
@@ -1,0 +1,32 @@
+name: eclipse-temurin-25-noble-maven-4
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - "eclipse-temurin-25-noble-maven-4/**"
+      - .github/workflows/eclipse-temurin-25-noble-maven-4.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+  pull_request:
+    paths:
+      - "eclipse-temurin-25-noble-maven-4/**"
+      - .github/workflows/eclipse-temurin-25-noble-maven-4.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+
+jobs:
+  build:
+    uses: ./.github/workflows/_template.yml
+    with:
+      directory: eclipse-temurin-25-noble-maven-4
+    secrets: inherit

--- a/.github/workflows/eclipse-temurin-25-noble.yml
+++ b/.github/workflows/eclipse-temurin-25-noble.yml
@@ -1,0 +1,32 @@
+name: eclipse-temurin-25-noble
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - "eclipse-temurin-25-noble/**"
+      - .github/workflows/eclipse-temurin-25-noble.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+  pull_request:
+    paths:
+      - "eclipse-temurin-25-noble/**"
+      - .github/workflows/eclipse-temurin-25-noble.yml
+      - .github/workflows/_template.yml
+      - common.sh
+      - tags-for-dir.sh
+      - "tests/**"
+      - "!tests/*.ps*"
+      - "!tests/*.windows"
+
+jobs:
+  build:
+    uses: ./.github/workflows/_template.yml
+    with:
+      directory: eclipse-temurin-25-noble
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ See Docker Hub or GitHub Container Registry for an updated list of tags
 * [eclipse-temurin-21-noble](https://github.com/carlossg/docker-maven/blob/main/eclipse-temurin-21-noble/Dockerfile)
 * [eclipse-temurin-24-alpine](https://github.com/carlossg/docker-maven/blob/main/eclipse-temurin-24-alpine/Dockerfile)
 * [eclipse-temurin-24-noble](https://github.com/carlossg/docker-maven/blob/main/eclipse-temurin-24-noble/Dockerfile)
+* [eclipse-temurin-25-alpine](https://github.com/carlossg/docker-maven/blob/main/eclipse-temurin-25-alpine/Dockerfile)
+* [eclipse-temurin-25-noble](https://github.com/carlossg/docker-maven/blob/main/eclipse-temurin-25-noble/Dockerfile)
 * [ibm-semeru-11-noble](https://github.com/carlossg/docker-maven/blob/main/ibm-semeru-11-noble/Dockerfile)
 * [ibm-semeru-17-noble](https://github.com/carlossg/docker-maven/blob/main/ibm-semeru-17-noble/Dockerfile)
 * [ibm-semeru-21-noble](https://github.com/carlossg/docker-maven/blob/main/ibm-semeru-21-noble/Dockerfile)
@@ -291,6 +293,79 @@ Some come from the parent images and some are installed in this image for backwa
 | sapmachine-17               | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
 | sapmachine-21               | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
 | sapmachine-24               | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+|                               | git | curl | tar | bash | which | gzip | procps | gpg | ssh |
+|-------------------------------|-----|------|-----|------|-------|------|--------|-----|-----|
+| amazoncorretto-8              |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-8-al2023       |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-8-alpine       |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| amazoncorretto-8-debian       |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| amazoncorretto-11             |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-11-al2023      |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-11-alpine      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| amazoncorretto-11-debian      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| amazoncorretto-17             |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-17-al2023      |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-17-alpine      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| amazoncorretto-17-debian      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| amazoncorretto-21             |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-21-al2023      |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-21-alpine      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| amazoncorretto-21-debian      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| amazoncorretto-24             |     | ✔︎    |     | ✔︎    |       | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-24-al2023      |     | ✔︎    |     | ✔︎    |       | ✔︎    |        | ✔︎   | ✔︎   |
+| amazoncorretto-24-alpine      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| amazoncorretto-24-debian      |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| azulzulu-8                    |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| azulzulu-8-alpine             |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| azulzulu-8-debian             |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| azulzulu-11                   |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| azulzulu-11-alpine            |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| azulzulu-11-debian            |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| azulzulu-17                   |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| azulzulu-17-alpine            |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| azulzulu-17-debian            |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| azulzulu-21                   |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| azulzulu-21-alpine            |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| azulzulu-21-debian            |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| azulzulu-24                   |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| azulzulu-24-alpine            |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| azulzulu-24-debian            |     |      | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| eclipse-temurin-8-alpine      |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| eclipse-temurin-8-noble       | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| eclipse-temurin-11-alpine     |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| eclipse-temurin-11-noble      | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| eclipse-temurin-17-alpine     |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| eclipse-temurin-17-noble      | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| eclipse-temurin-21-alpine     |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| eclipse-temurin-21-noble      | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| eclipse-temurin-24-alpine     |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| eclipse-temurin-24-noble      | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| eclipse-temurin-25-alpine     |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| eclipse-temurin-25-noble      | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| graalvm-community-17          |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| graalvm-community-21          |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| graalvm-community-24          |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        | ✔︎   | ✔︎   |
+| ibm-semeru-11-noble           | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| ibm-semeru-17-noble           | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| ibm-semeru-21-noble           | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| ibm-semeru-24-noble           | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| ibmjava-8                     |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| libericaopenjdk-8-alpine      |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| libericaopenjdk-8-debian      |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| libericaopenjdk-11-alpine     |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| libericaopenjdk-11-debian     |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| libericaopenjdk-17-alpine     |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| libericaopenjdk-17-debian     |     | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    |        |     | ✔︎   |
+| microsoft-openjdk-11-ubuntu   | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| microsoft-openjdk-17-ubuntu   | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| microsoft-openjdk-21-ubuntu   | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      | ✔︎   | ✔︎   |
+| oracle-graalvm-17             |     | ✔︎    | ✔︎   | ✔︎    |       | ✔︎    |        | ✔︎   | ✔︎   |
+| oracle-graalvm-21             |     | ✔︎    | ✔︎   | ✔︎    |       | ✔︎    |        | ✔︎   | ✔︎   |
+| oracle-graalvm-24             |     | ✔︎    | ✔︎   | ✔︎    |       | ✔︎    |        | ✔︎   | ✔︎   |
+| sapmachine-11                 | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| sapmachine-17                 | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| sapmachine-21                 | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
+| sapmachine-24                 | ✔︎   | ✔︎    | ✔︎   | ✔︎    | ✔︎     | ✔︎    | ✔︎      |     | ✔︎   |
 
 
 # Image Verification

--- a/eclipse-temurin-25-alpine-maven-4/Dockerfile
+++ b/eclipse-temurin-25-alpine-maven-4/Dockerfile
@@ -1,0 +1,24 @@
+FROM eclipse-temurin:25-jdk-alpine
+
+RUN apk add --no-cache bash procps curl tar openssh-client
+
+# common for all images
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+
+ENV MAVEN_HOME=/usr/share/maven
+
+COPY --from=ghcr.io/carlossg/maven:4.0.0-rc-4-eclipse-temurin-17 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=ghcr.io/carlossg/maven:4.0.0-rc-4-eclipse-temurin-17 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=ghcr.io/carlossg/maven:4.0.0-rc-4-eclipse-temurin-17 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=4.0.0-rc-4
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/eclipse-temurin-25-alpine/Dockerfile
+++ b/eclipse-temurin-25-alpine/Dockerfile
@@ -1,0 +1,24 @@
+FROM eclipse-temurin:25-jdk-alpine
+
+RUN apk add --no-cache bash procps curl tar openssh-client
+
+# common for all images
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+
+ENV MAVEN_HOME=/usr/share/maven
+
+COPY --from=maven:3.9.11-eclipse-temurin-17 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.11-eclipse-temurin-17 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.11-eclipse-temurin-17 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=3.9.11
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/eclipse-temurin-25-noble-maven-4/Dockerfile
+++ b/eclipse-temurin-25-noble-maven-4/Dockerfile
@@ -1,0 +1,27 @@
+# DEFAULT_FOR_VERSION (remove the -noble suffix)
+FROM eclipse-temurin:25-jdk-noble
+
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git openssh-client --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+
+ENV MAVEN_HOME=/usr/share/maven
+
+COPY --from=ghcr.io/carlossg/maven:4.0.0-rc-4-eclipse-temurin-17 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=ghcr.io/carlossg/maven:4.0.0-rc-4-eclipse-temurin-17 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=ghcr.io/carlossg/maven:4.0.0-rc-4-eclipse-temurin-17 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=4.0.0-rc-4
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]

--- a/eclipse-temurin-25-noble/Dockerfile
+++ b/eclipse-temurin-25-noble/Dockerfile
@@ -1,0 +1,27 @@
+# DEFAULT_FOR_VERSION (remove the -noble suffix)
+FROM eclipse-temurin:25-jdk-noble
+
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl git openssh-client --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
+
+# common for all images
+LABEL org.opencontainers.image.title="Apache Maven"
+LABEL org.opencontainers.image.source=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.url=https://github.com/carlossg/docker-maven
+LABEL org.opencontainers.image.description="Apache Maven is a software project management and comprehension tool. Based on the concept of a project object model (POM), Maven can manage a project's build, reporting and documentation from a central piece of information."
+
+ENV MAVEN_HOME=/usr/share/maven
+
+COPY --from=maven:3.9.11-eclipse-temurin-17 ${MAVEN_HOME} ${MAVEN_HOME}
+COPY --from=maven:3.9.11-eclipse-temurin-17 /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
+COPY --from=maven:3.9.11-eclipse-temurin-17 /usr/share/maven/ref/settings-docker.xml /usr/share/maven/ref/settings-docker.xml
+
+RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+
+ARG MAVEN_VERSION=3.9.11
+ARG USER_HOME_DIR="/root"
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+
+ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
+CMD ["mvn"]


### PR DESCRIPTION
## Summary

This pull request addsDockerfiles for Maven, specifically:
- Maven 4 and Maven 3 for the Eclipse Temurin 25 liberica and noble images.

## Changes

- Added Dockerfiles for the above configurations.
- Updated the README file to include new eclipse-temurin-25 entries.

Closes [issue 578](https://github.com/carlossg/docker-maven/issues/578).