### PR TITLE
chore: bump Maven from 3.9.14 to 3.9.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Run `update-maven-version.sh` to automatically update all files to the latest Ma
 
 Or target a specific version:
 
-    ./update-maven-version.sh 3.9.14
+    ./update-maven-version.sh 3.9.15
 
 The script will:
 * Replace all version references across Dockerfiles and scripts

--- a/amazoncorretto-11-al2023/Dockerfile
+++ b/amazoncorretto-11-al2023/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:11-al2023

--- a/amazoncorretto-11-alpine/Dockerfile
+++ b/amazoncorretto-11-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:11-alpine

--- a/amazoncorretto-11-debian/Dockerfile
+++ b/amazoncorretto-11-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release

--- a/amazoncorretto-11-windowsservercore/Dockerfile
+++ b/amazoncorretto-11-windowsservercore/Dockerfile
@@ -22,8 +22,8 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
 ENV JAVA_HOME=C:/ProgramData/jdk11.0.30_7
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
-ARG MAVEN_VERSION=3.9.14
-ARG SHA=4122c5e7a8794260539dd8fcd78480549511babff2f85e2b1258c8d4cf33c50af90f65d323f43c88d4959f35a8f37ced3eca802983caa6eb7cc81b16af936ab0
+ARG MAVEN_VERSION=3.9.15
+ARG SHA=251c676eb88684d6dd86c666817979d256a335c31ad34ab0e1df17eeca1cd504a6c890e906a46d04e51cc7a4fb02f33a75971ef750558034e0a81c257be02267
 ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/amazoncorretto-11/Dockerfile
+++ b/amazoncorretto-11/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:11

--- a/amazoncorretto-17-al2023/Dockerfile
+++ b/amazoncorretto-17-al2023/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:17-al2023

--- a/amazoncorretto-17-alpine/Dockerfile
+++ b/amazoncorretto-17-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:17-alpine

--- a/amazoncorretto-17-debian/Dockerfile
+++ b/amazoncorretto-17-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release

--- a/amazoncorretto-17-windowsservercore/Dockerfile
+++ b/amazoncorretto-17-windowsservercore/Dockerfile
@@ -22,8 +22,8 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
 ENV JAVA_HOME=C:/ProgramData/jdk17.0.18_9
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
-ARG MAVEN_VERSION=3.9.14
-ARG SHA=4122c5e7a8794260539dd8fcd78480549511babff2f85e2b1258c8d4cf33c50af90f65d323f43c88d4959f35a8f37ced3eca802983caa6eb7cc81b16af936ab0
+ARG MAVEN_VERSION=3.9.15
+ARG SHA=251c676eb88684d6dd86c666817979d256a335c31ad34ab0e1df17eeca1cd504a6c890e906a46d04e51cc7a4fb02f33a75971ef750558034e0a81c257be02267
 ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/amazoncorretto-17/Dockerfile
+++ b/amazoncorretto-17/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:17

--- a/amazoncorretto-21-al2023/Dockerfile
+++ b/amazoncorretto-21-al2023/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:21-al2023

--- a/amazoncorretto-21-alpine/Dockerfile
+++ b/amazoncorretto-21-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:21-alpine

--- a/amazoncorretto-21-debian/Dockerfile
+++ b/amazoncorretto-21-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release

--- a/amazoncorretto-21/Dockerfile
+++ b/amazoncorretto-21/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:21

--- a/amazoncorretto-25-al2023/Dockerfile
+++ b/amazoncorretto-25-al2023/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:25-al2023

--- a/amazoncorretto-25-alpine/Dockerfile
+++ b/amazoncorretto-25-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:25-alpine

--- a/amazoncorretto-25-debian/Dockerfile
+++ b/amazoncorretto-25-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release

--- a/amazoncorretto-25/Dockerfile
+++ b/amazoncorretto-25/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:25

--- a/amazoncorretto-8-al2023/Dockerfile
+++ b/amazoncorretto-8-al2023/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:8-al2023

--- a/amazoncorretto-8-alpine/Dockerfile
+++ b/amazoncorretto-8-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:8-alpine

--- a/amazoncorretto-8-debian/Dockerfile
+++ b/amazoncorretto-8-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release

--- a/amazoncorretto-8-windowsservercore/Dockerfile
+++ b/amazoncorretto-8-windowsservercore/Dockerfile
@@ -22,8 +22,8 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
 ENV JAVA_HOME=C:/ProgramData/jdk1.8.0_482
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
-ARG MAVEN_VERSION=3.9.14
-ARG SHA=4122c5e7a8794260539dd8fcd78480549511babff2f85e2b1258c8d4cf33c50af90f65d323f43c88d4959f35a8f37ced3eca802983caa6eb7cc81b16af936ab0
+ARG MAVEN_VERSION=3.9.15
+ARG SHA=251c676eb88684d6dd86c666817979d256a335c31ad34ab0e1df17eeca1cd504a6c890e906a46d04e51cc7a4fb02f33a75971ef750558034e0a81c257be02267
 ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/amazoncorretto-8/Dockerfile
+++ b/amazoncorretto-8/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:8

--- a/azulzulu-11-alpine/Dockerfile
+++ b/azulzulu-11-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:11

--- a/azulzulu-11-debian/Dockerfile
+++ b/azulzulu-11-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:11

--- a/azulzulu-11-windowsservercore/Dockerfile
+++ b/azulzulu-11-windowsservercore/Dockerfile
@@ -20,8 +20,8 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
     Remove-Item C:/${env:zip}
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
-ARG MAVEN_VERSION=3.9.14
-ARG SHA=4122c5e7a8794260539dd8fcd78480549511babff2f85e2b1258c8d4cf33c50af90f65d323f43c88d4959f35a8f37ced3eca802983caa6eb7cc81b16af936ab0
+ARG MAVEN_VERSION=3.9.15
+ARG SHA=251c676eb88684d6dd86c666817979d256a335c31ad34ab0e1df17eeca1cd504a6c890e906a46d04e51cc7a4fb02f33a75971ef750558034e0a81c257be02267
 ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/azulzulu-11/Dockerfile
+++ b/azulzulu-11/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:11

--- a/azulzulu-17-alpine/Dockerfile
+++ b/azulzulu-17-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:17

--- a/azulzulu-17-debian/Dockerfile
+++ b/azulzulu-17-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:17

--- a/azulzulu-17-windowsservercore/Dockerfile
+++ b/azulzulu-17-windowsservercore/Dockerfile
@@ -20,8 +20,8 @@ RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zi
     Remove-Item C:/${env:zip}
 
 ARG USER_HOME_DIR="C:/Users/ContainerUser"
-ARG MAVEN_VERSION=3.9.14
-ARG SHA=4122c5e7a8794260539dd8fcd78480549511babff2f85e2b1258c8d4cf33c50af90f65d323f43c88d4959f35a8f37ced3eca802983caa6eb7cc81b16af936ab0
+ARG MAVEN_VERSION=3.9.15
+ARG SHA=251c676eb88684d6dd86c666817979d256a335c31ad34ab0e1df17eeca1cd504a6c890e906a46d04e51cc7a4fb02f33a75971ef750558034e0a81c257be02267
 ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN Invoke-WebRequest -Uri ${env:BASE_URL}/apache-maven-${env:MAVEN_VERSION}-bin.zip?action=download -OutFile ${env:TEMP}/apache-maven.zip ; `

--- a/azulzulu-17/Dockerfile
+++ b/azulzulu-17/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:17

--- a/azulzulu-21-alpine/Dockerfile
+++ b/azulzulu-21-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:21

--- a/azulzulu-21-debian/Dockerfile
+++ b/azulzulu-21-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:21

--- a/azulzulu-21/Dockerfile
+++ b/azulzulu-21/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:21

--- a/azulzulu-24-alpine/Dockerfile
+++ b/azulzulu-24-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:24

--- a/azulzulu-24-debian/Dockerfile
+++ b/azulzulu-24-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:24

--- a/azulzulu-24/Dockerfile
+++ b/azulzulu-24/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:24

--- a/azulzulu-25-alpine/Dockerfile
+++ b/azulzulu-25-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:25

--- a/azulzulu-25-debian/Dockerfile
+++ b/azulzulu-25-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:25

--- a/azulzulu-25/Dockerfile
+++ b/azulzulu-25/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:25

--- a/azulzulu-8-alpine/Dockerfile
+++ b/azulzulu-8-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:8

--- a/azulzulu-8-debian/Dockerfile
+++ b/azulzulu-8-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:8

--- a/azulzulu-8/Dockerfile
+++ b/azulzulu-8/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:8

--- a/common.sh
+++ b/common.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # Default values for 'latest' tag
-latestMavenVersion='3.9.14'
+latestMavenVersion='3.9.15'
 latestMaven4Version='4.0.0-rc-5'
 latest='26'
 default_jdk=eclipse-temurin-$latest-noble

--- a/eclipse-temurin-11-alpine/Dockerfile
+++ b/eclipse-temurin-11-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:11-jdk-alpine

--- a/eclipse-temurin-11-noble/Dockerfile
+++ b/eclipse-temurin-11-noble/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)

--- a/eclipse-temurin-17-alpine/Dockerfile
+++ b/eclipse-temurin-17-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:17-jdk-alpine

--- a/eclipse-temurin-17-noble/Dockerfile
+++ b/eclipse-temurin-17-noble/Dockerfile
@@ -1,9 +1,9 @@
 # DEFAULT_FOR_VERSION (remove the -noble suffix)
 FROM eclipse-temurin:17-jdk-noble AS builder
 
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 ARG USER_HOME_DIR="/root"
-ARG SHA=d50af8ab5e6005b46a07f0ce9d3719e67cfdf898da988a84871304cd59fb1af0fef2f99dea709e6e66f21f732f905979b5c2dce6b6860406f60a70e84d9cf0b8
+ARG SHA=33d81e0ec785f0207e3e5e3ffb61863e1dca5784c15ac3fb5ff105f69cffbea484eb8d473ea60467a63f7b0570eef8622f2fed8eee96acbe668aa313391cddb3
 ARG BASE_URL=https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries
 
 ENV MAVEN_HOME=/usr/share/maven

--- a/eclipse-temurin-21-alpine/Dockerfile
+++ b/eclipse-temurin-21-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:21-jdk-alpine

--- a/eclipse-temurin-21-noble/Dockerfile
+++ b/eclipse-temurin-21-noble/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)

--- a/eclipse-temurin-25-alpine/Dockerfile
+++ b/eclipse-temurin-25-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:25-jdk-alpine

--- a/eclipse-temurin-25-noble/Dockerfile
+++ b/eclipse-temurin-25-noble/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)

--- a/eclipse-temurin-26-alpine/Dockerfile
+++ b/eclipse-temurin-26-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:26-jdk-alpine

--- a/eclipse-temurin-26-noble/Dockerfile
+++ b/eclipse-temurin-26-noble/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)

--- a/eclipse-temurin-8-alpine/Dockerfile
+++ b/eclipse-temurin-8-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:8-jdk-alpine

--- a/eclipse-temurin-8-noble/Dockerfile
+++ b/eclipse-temurin-8-noble/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)

--- a/github-action.ps1
+++ b/github-action.ps1
@@ -3,7 +3,7 @@ Write-Host "Starting"
 $dir = $args[0]
 $username = $args[1]
 $password = $args[2]
-$tags = @('3.9.14', '3.9', '3')
+$tags = @('3.9.15', '3.9', '3')
 
 # only push from main
 $ref=$env:GITHUB_REF

--- a/graalvm-community-17/Dockerfile
+++ b/graalvm-community-17/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:17

--- a/graalvm-community-21/Dockerfile
+++ b/graalvm-community-21/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:21

--- a/graalvm-community-24/Dockerfile
+++ b/graalvm-community-24/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:24

--- a/graalvm-community-25/Dockerfile
+++ b/graalvm-community-25/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:25

--- a/ibm-semeru-11-noble/Dockerfile
+++ b/ibm-semeru-11-noble/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM ibm-semeru-runtimes:open-11-jdk-noble

--- a/ibm-semeru-17-noble/Dockerfile
+++ b/ibm-semeru-17-noble/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM ibm-semeru-runtimes:open-17-jdk-noble

--- a/ibm-semeru-21-noble/Dockerfile
+++ b/ibm-semeru-21-noble/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM ibm-semeru-runtimes:open-21-jdk-noble

--- a/ibm-semeru-25-noble/Dockerfile
+++ b/ibm-semeru-25-noble/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM ibm-semeru-runtimes:open-25-jdk-noble

--- a/ibmjava-8/Dockerfile
+++ b/ibmjava-8/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM ibmjava:8-sdk

--- a/libericaopenjdk-11-alpine/Dockerfile
+++ b/libericaopenjdk-11-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-alpine:11

--- a/libericaopenjdk-11-debian/Dockerfile
+++ b/libericaopenjdk-11-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-debian:11

--- a/libericaopenjdk-17-alpine/Dockerfile
+++ b/libericaopenjdk-17-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-alpine:17

--- a/libericaopenjdk-17-debian/Dockerfile
+++ b/libericaopenjdk-17-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-debian:17

--- a/libericaopenjdk-25-alpine/Dockerfile
+++ b/libericaopenjdk-25-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-alpine:25

--- a/libericaopenjdk-25-debian/Dockerfile
+++ b/libericaopenjdk-25-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-debian:25

--- a/libericaopenjdk-8-alpine/Dockerfile
+++ b/libericaopenjdk-8-alpine/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-alpine:8

--- a/libericaopenjdk-8-debian/Dockerfile
+++ b/libericaopenjdk-8-debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-debian:8

--- a/microsoft-openjdk-11-ubuntu/Dockerfile
+++ b/microsoft-openjdk-11-ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM mcr.microsoft.com/openjdk/jdk:11-ubuntu

--- a/microsoft-openjdk-17-ubuntu/Dockerfile
+++ b/microsoft-openjdk-17-ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM mcr.microsoft.com/openjdk/jdk:17-ubuntu

--- a/microsoft-openjdk-21-ubuntu/Dockerfile
+++ b/microsoft-openjdk-21-ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu

--- a/microsoft-openjdk-25-ubuntu/Dockerfile
+++ b/microsoft-openjdk-25-ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM mcr.microsoft.com/openjdk/jdk:25-ubuntu

--- a/oracle-graalvm-17/Dockerfile
+++ b/oracle-graalvm-17/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:17

--- a/oracle-graalvm-21/Dockerfile
+++ b/oracle-graalvm-21/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:21

--- a/oracle-graalvm-24/Dockerfile
+++ b/oracle-graalvm-24/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:24

--- a/oracle-graalvm-25/Dockerfile
+++ b/oracle-graalvm-25/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:25

--- a/sapmachine-17/Dockerfile
+++ b/sapmachine-17/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:17

--- a/sapmachine-21/Dockerfile
+++ b/sapmachine-21/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:21

--- a/sapmachine-25/Dockerfile
+++ b/sapmachine-25/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:25

--- a/sapmachine-26/Dockerfile
+++ b/sapmachine-26/Dockerfile
@@ -1,4 +1,4 @@
-ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_VERSION=3.9.15
 FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:26


### PR DESCRIPTION
Bumps Maven from `3.9.14` to `3.9.15`.

- [Release notes](https://github.com/apache/maven/releases/tag/maven-3.9.15)
- [Maven download page](https://maven.apache.org/download.cgi)