### PR TITLE
feat: improve `publish.sh` and related documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,18 @@ In order to publish the images a PR needs to be opened against [docker-library/o
 
 For that we use `publish.sh` that runs `generate-stackbrew-library.sh`
 
+### Requirements
+
+- [docker-library/official-images](https://github.com/docker-library/official-images) repository forked and cloned locally on path `../../docker/official-images`
+- [bashbrew cli](https://github.com/docker-library/bashbrew) available on path
+- [sponge cli](https://formulae.brew.sh/formula/sponge) available on path
+
+### Usage
+
+```
+export BASHBREW_LIBRARY=$(pwd)/../../docker/official-images/library
+./publish.sh
+```
 # License
 
 View [license information](https://www.apache.org/licenses/) for the software contained in this image.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ For that we use `publish.sh` that runs `generate-stackbrew-library.sh`
 - [docker-library/official-images](https://github.com/docker-library/official-images) repository forked and cloned locally on path `../../docker/official-images`
 - [bashbrew cli](https://github.com/docker-library/bashbrew) available on path
 - [sponge cli](https://formulae.brew.sh/formula/sponge) available on path
+- [coreutils](https://formulae.brew.sh/formula/coreutils) and [gnu-sed](https://formulae.brew.sh/formula/gnu-sed) available on path (required for macOS)
 
 ### Usage
 

--- a/publish.sh
+++ b/publish.sh
@@ -47,7 +47,7 @@ for dir in "${all_dirs[@]}"; do
 				mv "$tmpfile" "$dir/Dockerfile"
 			fi
 			# copy from the main Dockerfile template the common lines
-			tail +2 Dockerfile-template >>"$dir/Dockerfile"
+			tail -n +2 Dockerfile-template >>"$dir/Dockerfile"
 		fi
 	fi
 done
@@ -86,7 +86,7 @@ find . -iname Dockerfile -exec grep -Hl "ARG uri=" {} \; | while read -r file; d
 done
 
 # Replace corretto.key sha
-new_sha=$(curl -sSfL https://apt.corretto.aws/corretto.key | sha256)
+new_sha=$(curl -sSfL https://apt.corretto.aws/corretto.key | sha256sum | awk '{print $1}')
 find . -maxdepth 2 -name Dockerfile -exec \
 	sed -i "s/echo '[0-9a-f]* \*corretto.key' | sha256sum/echo '${new_sha} \*corretto.key' | sha256sum/g" {} \+
 echo "Replaced corretto.key SHA in all files."


### PR DESCRIPTION
while trying to run `./publish.sh` I encountered some issues. To ease other newcomers to also run the script I have added requirements to the publish section. 
Also I have added option `-n` to tail call as my tail binary didn't accept `+2` without option flag. Finally I replaced `sha256` in pipe with `| sha256sum | awk '{print $1}'` as I was not able to find the binary for `sha256`