### PR TITLE
chore: use literal tag in FROM

### DIFF
--- a/amazoncorretto-11-al2023/Dockerfile
+++ b/amazoncorretto-11-al2023/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:11-al2023
 

--- a/amazoncorretto-11-alpine/Dockerfile
+++ b/amazoncorretto-11-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:11-alpine
 

--- a/amazoncorretto-11-debian/Dockerfile
+++ b/amazoncorretto-11-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
 # EXTRA_TAG_SUFFIXES=trixie

--- a/amazoncorretto-11/Dockerfile
+++ b/amazoncorretto-11/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:11
 

--- a/amazoncorretto-17-al2023-maven-4/Dockerfile
+++ b/amazoncorretto-17-al2023-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:17-al2023
 

--- a/amazoncorretto-17-al2023/Dockerfile
+++ b/amazoncorretto-17-al2023/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:17-al2023
 

--- a/amazoncorretto-17-alpine/Dockerfile
+++ b/amazoncorretto-17-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:17-alpine
 

--- a/amazoncorretto-17-debian-maven-4/Dockerfile
+++ b/amazoncorretto-17-debian-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
 # EXTRA_TAG_SUFFIXES=trixie

--- a/amazoncorretto-17-debian/Dockerfile
+++ b/amazoncorretto-17-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
 # EXTRA_TAG_SUFFIXES=trixie

--- a/amazoncorretto-17-maven-4/Dockerfile
+++ b/amazoncorretto-17-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:17
 

--- a/amazoncorretto-17/Dockerfile
+++ b/amazoncorretto-17/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:17
 

--- a/amazoncorretto-21-al2023-maven-4/Dockerfile
+++ b/amazoncorretto-21-al2023-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:21-al2023
 

--- a/amazoncorretto-21-al2023/Dockerfile
+++ b/amazoncorretto-21-al2023/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:21-al2023
 

--- a/amazoncorretto-21-alpine/Dockerfile
+++ b/amazoncorretto-21-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:21-alpine
 

--- a/amazoncorretto-21-debian-maven-4/Dockerfile
+++ b/amazoncorretto-21-debian-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
 # EXTRA_TAG_SUFFIXES=trixie

--- a/amazoncorretto-21-debian/Dockerfile
+++ b/amazoncorretto-21-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
 # EXTRA_TAG_SUFFIXES=trixie

--- a/amazoncorretto-21-maven-4/Dockerfile
+++ b/amazoncorretto-21-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:21
 

--- a/amazoncorretto-21/Dockerfile
+++ b/amazoncorretto-21/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:21
 

--- a/amazoncorretto-25-al2023-maven-4/Dockerfile
+++ b/amazoncorretto-25-al2023-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:25-al2023
 

--- a/amazoncorretto-25-al2023/Dockerfile
+++ b/amazoncorretto-25-al2023/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:25-al2023
 

--- a/amazoncorretto-25-alpine/Dockerfile
+++ b/amazoncorretto-25-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:25-alpine
 

--- a/amazoncorretto-25-debian-maven-4/Dockerfile
+++ b/amazoncorretto-25-debian-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
 # EXTRA_TAG_SUFFIXES=trixie

--- a/amazoncorretto-25-debian/Dockerfile
+++ b/amazoncorretto-25-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
 # EXTRA_TAG_SUFFIXES=trixie

--- a/amazoncorretto-25-maven-4/Dockerfile
+++ b/amazoncorretto-25-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:25
 

--- a/amazoncorretto-25/Dockerfile
+++ b/amazoncorretto-25/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:25
 

--- a/amazoncorretto-8-al2023/Dockerfile
+++ b/amazoncorretto-8-al2023/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:8-al2023
 

--- a/amazoncorretto-8-alpine/Dockerfile
+++ b/amazoncorretto-8-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:8-alpine
 

--- a/amazoncorretto-8-debian/Dockerfile
+++ b/amazoncorretto-8-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 # Update EXTRA_TAG_SUFFIXES to new release when changing to next stable debian release
 # EXTRA_TAG_SUFFIXES=trixie

--- a/amazoncorretto-8/Dockerfile
+++ b/amazoncorretto-8/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM amazoncorretto:8
 

--- a/azulzulu-11-alpine/Dockerfile
+++ b/azulzulu-11-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:11
 

--- a/azulzulu-11-debian/Dockerfile
+++ b/azulzulu-11-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:11
 

--- a/azulzulu-11/Dockerfile
+++ b/azulzulu-11/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:11
 

--- a/azulzulu-17-alpine-maven-4/Dockerfile
+++ b/azulzulu-17-alpine-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:17
 

--- a/azulzulu-17-alpine/Dockerfile
+++ b/azulzulu-17-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:17
 

--- a/azulzulu-17-debian/Dockerfile
+++ b/azulzulu-17-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:17
 

--- a/azulzulu-17-maven-4/Dockerfile
+++ b/azulzulu-17-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:17
 

--- a/azulzulu-17/Dockerfile
+++ b/azulzulu-17/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:17
 

--- a/azulzulu-21-alpine-maven-4/Dockerfile
+++ b/azulzulu-21-alpine-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:21
 

--- a/azulzulu-21-alpine/Dockerfile
+++ b/azulzulu-21-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:21
 

--- a/azulzulu-21-debian/Dockerfile
+++ b/azulzulu-21-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:21
 

--- a/azulzulu-21-maven-4/Dockerfile
+++ b/azulzulu-21-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:21
 

--- a/azulzulu-21/Dockerfile
+++ b/azulzulu-21/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:21
 

--- a/azulzulu-24-alpine-maven-4/Dockerfile
+++ b/azulzulu-24-alpine-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:24
 

--- a/azulzulu-24-alpine/Dockerfile
+++ b/azulzulu-24-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:24
 

--- a/azulzulu-24-debian/Dockerfile
+++ b/azulzulu-24-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:24
 

--- a/azulzulu-24-maven-4/Dockerfile
+++ b/azulzulu-24-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:24
 

--- a/azulzulu-24/Dockerfile
+++ b/azulzulu-24/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:24
 

--- a/azulzulu-25-alpine-maven-4/Dockerfile
+++ b/azulzulu-25-alpine-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:25
 

--- a/azulzulu-25-alpine/Dockerfile
+++ b/azulzulu-25-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:25
 

--- a/azulzulu-25-debian/Dockerfile
+++ b/azulzulu-25-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:25
 

--- a/azulzulu-25-maven-4/Dockerfile
+++ b/azulzulu-25-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:25
 

--- a/azulzulu-25/Dockerfile
+++ b/azulzulu-25/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:25
 

--- a/azulzulu-8-alpine/Dockerfile
+++ b/azulzulu-8-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-alpine:8
 

--- a/azulzulu-8-debian/Dockerfile
+++ b/azulzulu-8-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk-debian:8
 

--- a/azulzulu-8/Dockerfile
+++ b/azulzulu-8/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM azul/zulu-openjdk:8
 

--- a/common.sh
+++ b/common.sh
@@ -37,7 +37,11 @@ version-aliases() {
 	local branch=$2
 
 	local dockerfileMavenVersion
-	dockerfileMavenVersion="$(grep -m1 'ARG MAVEN_VERSION=' "$dir/Dockerfile" | cut -d'=' -f2)"
+	dockerfileMavenVersion="$(grep -m1 '^FROM maven:' "$dir/Dockerfile" | sed -E -n 's|^FROM maven:([^ ]+)-eclipse-temurin.*|\1|p')"
+	# fallback for source-build images (e.g. eclipse-temurin-17-noble) that have no FROM maven: line
+	if [ -z "$dockerfileMavenVersion" ]; then
+		dockerfileMavenVersion="$(grep -m1 'ARG MAVEN_VERSION=' "$dir/Dockerfile" | cut -d'=' -f2)"
+	fi
 	local mavenVersion="${dockerfileMavenVersion}"
 
 	local extraSuffixes=()

--- a/eclipse-temurin-11-alpine/Dockerfile
+++ b/eclipse-temurin-11-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:11-jdk-alpine
 

--- a/eclipse-temurin-11-noble/Dockerfile
+++ b/eclipse-temurin-11-noble/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)
 FROM eclipse-temurin:11-jdk-noble

--- a/eclipse-temurin-17-alpine-maven-4/Dockerfile
+++ b/eclipse-temurin-17-alpine-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:17-jdk-alpine
 

--- a/eclipse-temurin-17-alpine/Dockerfile
+++ b/eclipse-temurin-17-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:17-jdk-alpine
 

--- a/eclipse-temurin-21-alpine-maven-4/Dockerfile
+++ b/eclipse-temurin-21-alpine-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:21-jdk-alpine
 

--- a/eclipse-temurin-21-alpine/Dockerfile
+++ b/eclipse-temurin-21-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:21-jdk-alpine
 

--- a/eclipse-temurin-21-noble-maven-4/Dockerfile
+++ b/eclipse-temurin-21-noble-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)
 FROM eclipse-temurin:21-jdk-noble

--- a/eclipse-temurin-21-noble/Dockerfile
+++ b/eclipse-temurin-21-noble/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)
 FROM eclipse-temurin:21-jdk-noble

--- a/eclipse-temurin-25-alpine-maven-4/Dockerfile
+++ b/eclipse-temurin-25-alpine-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:25-jdk-alpine
 

--- a/eclipse-temurin-25-alpine/Dockerfile
+++ b/eclipse-temurin-25-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:25-jdk-alpine
 

--- a/eclipse-temurin-25-noble-maven-4/Dockerfile
+++ b/eclipse-temurin-25-noble-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)
 FROM eclipse-temurin:25-jdk-noble

--- a/eclipse-temurin-25-noble/Dockerfile
+++ b/eclipse-temurin-25-noble/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)
 FROM eclipse-temurin:25-jdk-noble

--- a/eclipse-temurin-26-alpine-maven-4/Dockerfile
+++ b/eclipse-temurin-26-alpine-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:26-jdk-alpine
 

--- a/eclipse-temurin-26-alpine/Dockerfile
+++ b/eclipse-temurin-26-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:26-jdk-alpine
 

--- a/eclipse-temurin-26-noble-maven-4/Dockerfile
+++ b/eclipse-temurin-26-noble-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)
 FROM eclipse-temurin:26-jdk-noble

--- a/eclipse-temurin-26-noble/Dockerfile
+++ b/eclipse-temurin-26-noble/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)
 FROM eclipse-temurin:26-jdk-noble

--- a/eclipse-temurin-8-alpine/Dockerfile
+++ b/eclipse-temurin-8-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM eclipse-temurin:8-jdk-alpine
 

--- a/eclipse-temurin-8-noble/Dockerfile
+++ b/eclipse-temurin-8-noble/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 # DEFAULT_FOR_VERSION (remove the -noble suffix)
 FROM eclipse-temurin:8-jdk-noble

--- a/graalvm-community-17-maven-4/Dockerfile
+++ b/graalvm-community-17-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:17
 

--- a/graalvm-community-17/Dockerfile
+++ b/graalvm-community-17/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:17
 

--- a/graalvm-community-21-maven-4/Dockerfile
+++ b/graalvm-community-21-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:21
 

--- a/graalvm-community-21/Dockerfile
+++ b/graalvm-community-21/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:21
 

--- a/graalvm-community-24-maven-4/Dockerfile
+++ b/graalvm-community-24-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:24
 

--- a/graalvm-community-24/Dockerfile
+++ b/graalvm-community-24/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:24
 

--- a/graalvm-community-25-maven-4/Dockerfile
+++ b/graalvm-community-25-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:25
 

--- a/graalvm-community-25/Dockerfile
+++ b/graalvm-community-25/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM ghcr.io/graalvm/graalvm-community:25
 

--- a/ibm-semeru-11-noble/Dockerfile
+++ b/ibm-semeru-11-noble/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM ibm-semeru-runtimes:open-11-jdk-noble
 

--- a/ibm-semeru-17-noble-maven-4/Dockerfile
+++ b/ibm-semeru-17-noble-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM ibm-semeru-runtimes:open-17-jdk-noble
 

--- a/ibm-semeru-17-noble/Dockerfile
+++ b/ibm-semeru-17-noble/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM ibm-semeru-runtimes:open-17-jdk-noble
 

--- a/ibm-semeru-21-noble-maven-4/Dockerfile
+++ b/ibm-semeru-21-noble-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM ibm-semeru-runtimes:open-21-jdk-noble
 

--- a/ibm-semeru-21-noble/Dockerfile
+++ b/ibm-semeru-21-noble/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM ibm-semeru-runtimes:open-21-jdk-noble
 

--- a/ibm-semeru-25-noble-maven-4/Dockerfile
+++ b/ibm-semeru-25-noble-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM ibm-semeru-runtimes:open-25-jdk-noble
 

--- a/ibm-semeru-25-noble/Dockerfile
+++ b/ibm-semeru-25-noble/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM ibm-semeru-runtimes:open-25-jdk-noble
 

--- a/ibmjava-8/Dockerfile
+++ b/ibmjava-8/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM ibmjava:8-sdk
 

--- a/libericaopenjdk-11-alpine/Dockerfile
+++ b/libericaopenjdk-11-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-alpine:11
 

--- a/libericaopenjdk-11-debian/Dockerfile
+++ b/libericaopenjdk-11-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-debian:11
 

--- a/libericaopenjdk-17-alpine-maven-4/Dockerfile
+++ b/libericaopenjdk-17-alpine-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-alpine:17
 

--- a/libericaopenjdk-17-alpine/Dockerfile
+++ b/libericaopenjdk-17-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-alpine:17
 

--- a/libericaopenjdk-17-debian-maven-4/Dockerfile
+++ b/libericaopenjdk-17-debian-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-debian:17
 

--- a/libericaopenjdk-17-debian/Dockerfile
+++ b/libericaopenjdk-17-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-debian:17
 

--- a/libericaopenjdk-25-alpine-maven-4/Dockerfile
+++ b/libericaopenjdk-25-alpine-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-alpine:25
 

--- a/libericaopenjdk-25-alpine/Dockerfile
+++ b/libericaopenjdk-25-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-alpine:25
 

--- a/libericaopenjdk-25-debian-maven-4/Dockerfile
+++ b/libericaopenjdk-25-debian-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-debian:25
 

--- a/libericaopenjdk-25-debian/Dockerfile
+++ b/libericaopenjdk-25-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-debian:25
 

--- a/libericaopenjdk-8-alpine/Dockerfile
+++ b/libericaopenjdk-8-alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-alpine:8
 

--- a/libericaopenjdk-8-debian/Dockerfile
+++ b/libericaopenjdk-8-debian/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM bellsoft/liberica-openjdk-debian:8
 

--- a/microsoft-openjdk-11-ubuntu/Dockerfile
+++ b/microsoft-openjdk-11-ubuntu/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM mcr.microsoft.com/openjdk/jdk:11-ubuntu
 

--- a/microsoft-openjdk-17-ubuntu-maven-4/Dockerfile
+++ b/microsoft-openjdk-17-ubuntu-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM mcr.microsoft.com/openjdk/jdk:17-ubuntu
 

--- a/microsoft-openjdk-17-ubuntu/Dockerfile
+++ b/microsoft-openjdk-17-ubuntu/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM mcr.microsoft.com/openjdk/jdk:17-ubuntu
 

--- a/microsoft-openjdk-21-ubuntu-maven-4/Dockerfile
+++ b/microsoft-openjdk-21-ubuntu-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu
 

--- a/microsoft-openjdk-21-ubuntu/Dockerfile
+++ b/microsoft-openjdk-21-ubuntu/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu
 

--- a/microsoft-openjdk-25-ubuntu-maven-4/Dockerfile
+++ b/microsoft-openjdk-25-ubuntu-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM mcr.microsoft.com/openjdk/jdk:25-ubuntu
 

--- a/microsoft-openjdk-25-ubuntu/Dockerfile
+++ b/microsoft-openjdk-25-ubuntu/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM mcr.microsoft.com/openjdk/jdk:25-ubuntu
 

--- a/oracle-graalvm-17-maven-4/Dockerfile
+++ b/oracle-graalvm-17-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:17
 

--- a/oracle-graalvm-17/Dockerfile
+++ b/oracle-graalvm-17/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:17
 

--- a/oracle-graalvm-21-maven-4/Dockerfile
+++ b/oracle-graalvm-21-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:21
 

--- a/oracle-graalvm-21/Dockerfile
+++ b/oracle-graalvm-21/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:21
 

--- a/oracle-graalvm-24-maven-4/Dockerfile
+++ b/oracle-graalvm-24-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:24
 

--- a/oracle-graalvm-24/Dockerfile
+++ b/oracle-graalvm-24/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:24
 

--- a/oracle-graalvm-25-maven-4/Dockerfile
+++ b/oracle-graalvm-25-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:25
 

--- a/oracle-graalvm-25/Dockerfile
+++ b/oracle-graalvm-25/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM container-registry.oracle.com/graalvm/native-image:25
 

--- a/publish.sh
+++ b/publish.sh
@@ -37,11 +37,10 @@ for dir in "${all_dirs[@]}"; do
 				tmpfile="$(mktemp)"
 				{
 					if [[ "$dir" == *"maven-4"* ]]; then
-						echo "ARG MAVEN_VERSION=${latestMaven4Version}"
+						echo "FROM maven:${latestMaven4Version}-eclipse-temurin-17 AS maven_upstream"
 					else
-						echo "ARG MAVEN_VERSION=${latestMavenVersion}"
+						echo "FROM maven:${latestMavenVersion}-eclipse-temurin-17 AS maven_upstream"
 					fi
-					echo 'FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream'
 					echo ''
 					cat "$dir/Dockerfile"
 				} >"$tmpfile"

--- a/sapmachine-17-maven-4/Dockerfile
+++ b/sapmachine-17-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:17
 

--- a/sapmachine-17/Dockerfile
+++ b/sapmachine-17/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:17
 

--- a/sapmachine-21-maven-4/Dockerfile
+++ b/sapmachine-21-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:21
 

--- a/sapmachine-21/Dockerfile
+++ b/sapmachine-21/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:21
 

--- a/sapmachine-25-maven-4/Dockerfile
+++ b/sapmachine-25-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:25
 

--- a/sapmachine-25/Dockerfile
+++ b/sapmachine-25/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:25
 

--- a/sapmachine-26-maven-4/Dockerfile
+++ b/sapmachine-26-maven-4/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=4.0.0-rc-5
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:26
 

--- a/sapmachine-26/Dockerfile
+++ b/sapmachine-26/Dockerfile
@@ -1,5 +1,4 @@
-ARG MAVEN_VERSION=3.9.15
-FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
+FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
 
 FROM sapmachine:26
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -22,7 +22,7 @@ base_image=eclipse-temurin-17-noble
 		child_dockerfile=$BATS_TEST_DIRNAME/../$SUT_TAG/Dockerfile
 		base_tag=$(grep -m 1 '^FROM maven:' "$child_dockerfile" | sed -E 's/^FROM ([^[:space:]]+)( AS maven_upstream)?$/\1/')
 		if [[ "$base_tag" == *'${MAVEN_VERSION}'* ]]; then
-			maven_version=$(grep -m 1 '^ARG MAVEN_VERSION=' "$child_dockerfile" | sed 's/^ARG MAVEN_VERSION=//')
+            maven_version=$(grep -m 1 '^FROM maven:' "$child_dockerfile" | sed -E -n 's|^FROM maven:([^ ]+)-eclipse-temurin.*|\1|p')
 			base_tag="${base_tag//\$\{MAVEN_VERSION\}/$maven_version}"
 		fi
 		echo "Using base image: $base_tag"
@@ -52,14 +52,17 @@ base_image=eclipse-temurin-17-noble
 }
 
 @test "$SUT_TAG create test container" {
-	version="$(grep -m 1 'ARG MAVEN_VERSION' $BATS_TEST_DIRNAME/../$SUT_TAG/Dockerfile | sed -e 's/ARG MAVEN_VERSION=//')"
+    version="$(grep -m 1 '^FROM maven:' $BATS_TEST_DIRNAME/../$SUT_TAG/Dockerfile | sed -E -n 's|^FROM maven:([^ ]+)-eclipse-temurin.*|\1|p')"
+	if [ -z "$version" ]; then
+		version="$(grep -m 1 'ARG MAVEN_VERSION=' $BATS_TEST_DIRNAME/../$SUT_TAG/Dockerfile | cut -d'=' -f2)"
+	fi
 	run docker run --rm $SUT_IMAGE:$SUT_TAG mvn -version
 	assert_success
 	assert_line -p "Apache Maven $version "
 }
 
 # @test "$SUT_TAG create test container (-u 11337:11337)" {
-# 	version="$(grep -m 1 'ARG MAVEN_VERSION' $BATS_TEST_DIRNAME/../$SUT_TAG/Dockerfile | sed -e 's/ARG MAVEN_VERSION=//')"
+# 	version="$(grep -m 1 '^FROM maven:' $BATS_TEST_DIRNAME/../$SUT_TAG/Dockerfile | sed -E 's|^FROM maven:([^ ]+)-eclipse-temurin.*|\1|')"
 # 	run docker run --rm -u 11337:11337 -e HOME=/tmp $SUT_IMAGE:$SUT_TAG mvn -version
 # 	assert_success
 # 	assert_line -p "Apache Maven $version "


### PR DESCRIPTION
I got a comment on https://github.com/docker-library/official-images/pull/21275 

> ```diff
> +ARG MAVEN_VERSION=3.9.15
> +FROM maven:${MAVEN_VERSION}-eclipse-temurin-17 AS maven_upstream
> ```
> 
> Because our build system has to be able to query/calculate inter-image dependencies, we unfortunately do not support parameterized `FROM` values. This applies whether the substitution covers the whole reference or just part of the tag -- `maven:${MAVEN_VERSION}-eclipse-temurin-17` is as much of a hard blocker as `FROM $BASE_IMAGE` would be.
> 
> The intent here (deduplicate the tag string across three `COPY --from=` lines) is good, and using a named intermediate stage is a perfectly reasonable way to achieve it; the `FROM` itself just needs to be a literal:
> 
> ```dockerfile
> FROM maven:3.9.15-eclipse-temurin-17 AS maven_upstream
> 
> FROM amazoncorretto:11-al2023
> # ...
> COPY --from=maven_upstream ${MAVEN_HOME} ${MAVEN_HOME}
> COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-entrypoint.sh
> ```
> 
> This applies to every `Dockerfile` in the PR that uses the new pattern -- all of the 3.x and 4.0.0-rc-5 variant `Dockerfile`s will need the literal tag in the `FROM ... AS maven_upstream` line. 😅



So I removed parametrised tags in the `FROM` to comply to docker library constraints