### PR TITLE
fix: use Ubuntu 24.04 for noble image

### DIFF
--- a/eclipse-temurin-17-noble/Dockerfile
+++ b/eclipse-temurin-17-noble/Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir -p ${MAVEN_HOME} ${MAVEN_HOME}/ref \
 RUN mvn --version
 
 
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:17-jdk-noble
 
 RUN apt-get update \
   && apt-get install -y ca-certificates curl git openssh-client --no-install-recommends \


### PR DESCRIPTION
Use Ubuntu 24.04 base image (eclipse-termurin-17-noble) for the Eclipse Temurin 17 Noble docker image. 
This is the same setup as in `eclipse-temurin-17-noble-maven-4/Dockerfile`

fixes #652 