### PR TITLE
Generate toolchains.xml

### DIFF
--- a/Dockerfile-template
+++ b/Dockerfile-template
@@ -12,6 +12,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-11-al2023/Dockerfile
+++ b/amazoncorretto-11-al2023/Dockerfile
@@ -19,6 +19,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-11-alpine/Dockerfile
+++ b/amazoncorretto-11-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-11-debian/Dockerfile
+++ b/amazoncorretto-11-debian/Dockerfile
@@ -39,6 +39,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-11-windowsservercore/Dockerfile
+++ b/amazoncorretto-11-windowsservercore/Dockerfile
@@ -43,6 +43,8 @@ RUN setx /M PATH $('{0};{1}' -f $env:PATH,'C:\ProgramData\Maven\bin') | Out-Null
 
 USER ContainerUser
 ENV JAVA_HOME=${JAVA_HOME}
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Maven/mvn-entrypoint.ps1"]
 CMD ["mvn"]

--- a/amazoncorretto-11/Dockerfile
+++ b/amazoncorretto-11/Dockerfile
@@ -19,6 +19,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-17-al2023-maven-4/Dockerfile
+++ b/amazoncorretto-17-al2023-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-17-al2023/Dockerfile
+++ b/amazoncorretto-17-al2023/Dockerfile
@@ -19,6 +19,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-17-alpine/Dockerfile
+++ b/amazoncorretto-17-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-17-debian-maven-4/Dockerfile
+++ b/amazoncorretto-17-debian-maven-4/Dockerfile
@@ -39,6 +39,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-17-debian/Dockerfile
+++ b/amazoncorretto-17-debian/Dockerfile
@@ -39,6 +39,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-17-maven-4/Dockerfile
+++ b/amazoncorretto-17-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-17-windowsservercore-maven-4/Dockerfile
+++ b/amazoncorretto-17-windowsservercore-maven-4/Dockerfile
@@ -43,6 +43,8 @@ RUN setx /M PATH $('{0};{1}' -f $env:PATH,'C:\ProgramData\Maven\bin') | Out-Null
 
 USER ContainerUser
 ENV JAVA_HOME=${JAVA_HOME}
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Maven/mvn-entrypoint.ps1"]
 CMD ["mvn"]

--- a/amazoncorretto-17-windowsservercore/Dockerfile
+++ b/amazoncorretto-17-windowsservercore/Dockerfile
@@ -43,6 +43,8 @@ RUN setx /M PATH $('{0};{1}' -f $env:PATH,'C:\ProgramData\Maven\bin') | Out-Null
 
 USER ContainerUser
 ENV JAVA_HOME=${JAVA_HOME}
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Maven/mvn-entrypoint.ps1"]
 CMD ["mvn"]

--- a/amazoncorretto-17/Dockerfile
+++ b/amazoncorretto-17/Dockerfile
@@ -19,6 +19,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-21-al2023-maven-4/Dockerfile
+++ b/amazoncorretto-21-al2023-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-21-al2023/Dockerfile
+++ b/amazoncorretto-21-al2023/Dockerfile
@@ -19,6 +19,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-21-alpine/Dockerfile
+++ b/amazoncorretto-21-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-21-debian-maven-4/Dockerfile
+++ b/amazoncorretto-21-debian-maven-4/Dockerfile
@@ -39,6 +39,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-21-debian/Dockerfile
+++ b/amazoncorretto-21-debian/Dockerfile
@@ -39,6 +39,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-21-maven-4/Dockerfile
+++ b/amazoncorretto-21-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-21/Dockerfile
+++ b/amazoncorretto-21/Dockerfile
@@ -19,6 +19,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-25-al2023-maven-4/Dockerfile
+++ b/amazoncorretto-25-al2023-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-25-al2023/Dockerfile
+++ b/amazoncorretto-25-al2023/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-25-alpine/Dockerfile
+++ b/amazoncorretto-25-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-25-debian-maven-4/Dockerfile
+++ b/amazoncorretto-25-debian-maven-4/Dockerfile
@@ -39,6 +39,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-25-debian/Dockerfile
+++ b/amazoncorretto-25-debian/Dockerfile
@@ -39,6 +39,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-25-maven-4/Dockerfile
+++ b/amazoncorretto-25-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-25/Dockerfile
+++ b/amazoncorretto-25/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-8-al2023/Dockerfile
+++ b/amazoncorretto-8-al2023/Dockerfile
@@ -19,6 +19,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-8-alpine/Dockerfile
+++ b/amazoncorretto-8-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-8-debian/Dockerfile
+++ b/amazoncorretto-8-debian/Dockerfile
@@ -39,6 +39,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/amazoncorretto-8-windowsservercore/Dockerfile
+++ b/amazoncorretto-8-windowsservercore/Dockerfile
@@ -43,6 +43,8 @@ RUN setx /M PATH $('{0};{1}' -f $env:PATH,'C:\ProgramData\Maven\bin') | Out-Null
 
 USER ContainerUser
 ENV JAVA_HOME=${JAVA_HOME}
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Maven/mvn-entrypoint.ps1"]
 CMD ["mvn"]

--- a/amazoncorretto-8/Dockerfile
+++ b/amazoncorretto-8/Dockerfile
@@ -19,6 +19,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-11-alpine/Dockerfile
+++ b/azulzulu-11-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-11-debian/Dockerfile
+++ b/azulzulu-11-debian/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-11-windowsservercore/Dockerfile
+++ b/azulzulu-11-windowsservercore/Dockerfile
@@ -43,6 +43,8 @@ RUN setx /M PATH $('{0};{1}' -f $env:PATH,'C:\ProgramData\Maven\bin') | Out-Null
 
 USER ContainerUser
 ENV JAVA_HOME=${JAVA_HOME}
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Maven/mvn-entrypoint.ps1"]
 CMD ["mvn"]

--- a/azulzulu-11/Dockerfile
+++ b/azulzulu-11/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-17-alpine-maven-4/Dockerfile
+++ b/azulzulu-17-alpine-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-17-alpine/Dockerfile
+++ b/azulzulu-17-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-17-debian/Dockerfile
+++ b/azulzulu-17-debian/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-17-maven-4/Dockerfile
+++ b/azulzulu-17-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-17-windowsservercore-maven-4/Dockerfile
+++ b/azulzulu-17-windowsservercore-maven-4/Dockerfile
@@ -43,6 +43,8 @@ RUN setx /M PATH $('{0};{1}' -f $env:PATH,'C:\ProgramData\Maven\bin') | Out-Null
 
 USER ContainerUser
 ENV JAVA_HOME=${JAVA_HOME}
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Maven/mvn-entrypoint.ps1"]
 CMD ["mvn"]

--- a/azulzulu-17-windowsservercore/Dockerfile
+++ b/azulzulu-17-windowsservercore/Dockerfile
@@ -43,6 +43,8 @@ RUN setx /M PATH $('{0};{1}' -f $env:PATH,'C:\ProgramData\Maven\bin') | Out-Null
 
 USER ContainerUser
 ENV JAVA_HOME=${JAVA_HOME}
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["powershell.exe", "-f", "C:/ProgramData/Maven/mvn-entrypoint.ps1"]
 CMD ["mvn"]

--- a/azulzulu-17/Dockerfile
+++ b/azulzulu-17/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-21-alpine-maven-4/Dockerfile
+++ b/azulzulu-21-alpine-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-21-alpine/Dockerfile
+++ b/azulzulu-21-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-21-debian/Dockerfile
+++ b/azulzulu-21-debian/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-21-maven-4/Dockerfile
+++ b/azulzulu-21-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-21/Dockerfile
+++ b/azulzulu-21/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-24-alpine-maven-4/Dockerfile
+++ b/azulzulu-24-alpine-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-24-alpine/Dockerfile
+++ b/azulzulu-24-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-24-debian/Dockerfile
+++ b/azulzulu-24-debian/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-24-maven-4/Dockerfile
+++ b/azulzulu-24-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-24/Dockerfile
+++ b/azulzulu-24/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-25-alpine-maven-4/Dockerfile
+++ b/azulzulu-25-alpine-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-25-alpine/Dockerfile
+++ b/azulzulu-25-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-25-debian/Dockerfile
+++ b/azulzulu-25-debian/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-25-maven-4/Dockerfile
+++ b/azulzulu-25-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-25/Dockerfile
+++ b/azulzulu-25/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-8-alpine/Dockerfile
+++ b/azulzulu-8-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-8-debian/Dockerfile
+++ b/azulzulu-8-debian/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/azulzulu-8/Dockerfile
+++ b/azulzulu-8/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-11-alpine/Dockerfile
+++ b/eclipse-temurin-11-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-11-noble/Dockerfile
+++ b/eclipse-temurin-11-noble/Dockerfile
@@ -21,6 +21,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-17-alpine-maven-4/Dockerfile
+++ b/eclipse-temurin-17-alpine-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-17-alpine/Dockerfile
+++ b/eclipse-temurin-17-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-17-noble-maven-4/Dockerfile
+++ b/eclipse-temurin-17-noble-maven-4/Dockerfile
@@ -56,6 +56,8 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG MAVEN_VERSION=4.0.0-rc-5
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-17-noble/Dockerfile
+++ b/eclipse-temurin-17-noble/Dockerfile
@@ -53,6 +53,8 @@ RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-21-alpine-maven-4/Dockerfile
+++ b/eclipse-temurin-21-alpine-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-21-alpine/Dockerfile
+++ b/eclipse-temurin-21-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-21-noble-maven-4/Dockerfile
+++ b/eclipse-temurin-21-noble-maven-4/Dockerfile
@@ -21,6 +21,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-21-noble/Dockerfile
+++ b/eclipse-temurin-21-noble/Dockerfile
@@ -21,6 +21,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-25-alpine-maven-4/Dockerfile
+++ b/eclipse-temurin-25-alpine-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-25-alpine/Dockerfile
+++ b/eclipse-temurin-25-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-25-noble-maven-4/Dockerfile
+++ b/eclipse-temurin-25-noble-maven-4/Dockerfile
@@ -21,6 +21,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-25-noble/Dockerfile
+++ b/eclipse-temurin-25-noble/Dockerfile
@@ -21,6 +21,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-26-alpine-maven-4/Dockerfile
+++ b/eclipse-temurin-26-alpine-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-26-alpine/Dockerfile
+++ b/eclipse-temurin-26-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-26-noble-maven-4/Dockerfile
+++ b/eclipse-temurin-26-noble-maven-4/Dockerfile
@@ -21,6 +21,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-26-noble/Dockerfile
+++ b/eclipse-temurin-26-noble/Dockerfile
@@ -21,6 +21,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-8-alpine/Dockerfile
+++ b/eclipse-temurin-8-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/eclipse-temurin-8-noble/Dockerfile
+++ b/eclipse-temurin-8-noble/Dockerfile
@@ -21,6 +21,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/graalvm-community-17-maven-4/Dockerfile
+++ b/graalvm-community-17-maven-4/Dockerfile
@@ -17,6 +17,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/graalvm-community-17/Dockerfile
+++ b/graalvm-community-17/Dockerfile
@@ -17,6 +17,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/graalvm-community-21-maven-4/Dockerfile
+++ b/graalvm-community-21-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/graalvm-community-21/Dockerfile
+++ b/graalvm-community-21/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/graalvm-community-24-maven-4/Dockerfile
+++ b/graalvm-community-24-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/graalvm-community-24/Dockerfile
+++ b/graalvm-community-24/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/graalvm-community-25-maven-4/Dockerfile
+++ b/graalvm-community-25-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/graalvm-community-25/Dockerfile
+++ b/graalvm-community-25/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibm-semeru-11-noble/Dockerfile
+++ b/ibm-semeru-11-noble/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibm-semeru-17-noble-maven-4/Dockerfile
+++ b/ibm-semeru-17-noble-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibm-semeru-17-noble/Dockerfile
+++ b/ibm-semeru-17-noble/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibm-semeru-21-noble-maven-4/Dockerfile
+++ b/ibm-semeru-21-noble-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibm-semeru-21-noble/Dockerfile
+++ b/ibm-semeru-21-noble/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibm-semeru-25-noble-maven-4/Dockerfile
+++ b/ibm-semeru-25-noble-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibm-semeru-25-noble/Dockerfile
+++ b/ibm-semeru-25-noble/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/ibmjava-8/Dockerfile
+++ b/ibmjava-8/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-11-alpine/Dockerfile
+++ b/libericaopenjdk-11-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-11-debian/Dockerfile
+++ b/libericaopenjdk-11-debian/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-17-alpine-maven-4/Dockerfile
+++ b/libericaopenjdk-17-alpine-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-17-alpine/Dockerfile
+++ b/libericaopenjdk-17-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-17-debian-maven-4/Dockerfile
+++ b/libericaopenjdk-17-debian-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-17-debian/Dockerfile
+++ b/libericaopenjdk-17-debian/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-25-alpine-maven-4/Dockerfile
+++ b/libericaopenjdk-25-alpine-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-25-alpine/Dockerfile
+++ b/libericaopenjdk-25-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-25-debian-maven-4/Dockerfile
+++ b/libericaopenjdk-25-debian-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-25-debian/Dockerfile
+++ b/libericaopenjdk-25-debian/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-8-alpine/Dockerfile
+++ b/libericaopenjdk-8-alpine/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/libericaopenjdk-8-debian/Dockerfile
+++ b/libericaopenjdk-8-debian/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-11-ubuntu/Dockerfile
+++ b/microsoft-openjdk-11-ubuntu/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-17-ubuntu-maven-4/Dockerfile
+++ b/microsoft-openjdk-17-ubuntu-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-17-ubuntu/Dockerfile
+++ b/microsoft-openjdk-17-ubuntu/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-21-ubuntu-maven-4/Dockerfile
+++ b/microsoft-openjdk-21-ubuntu-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-21-ubuntu/Dockerfile
+++ b/microsoft-openjdk-21-ubuntu/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-25-ubuntu-maven-4/Dockerfile
+++ b/microsoft-openjdk-25-ubuntu-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/microsoft-openjdk-25-ubuntu/Dockerfile
+++ b/microsoft-openjdk-25-ubuntu/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/oracle-graalvm-17-maven-4/Dockerfile
+++ b/oracle-graalvm-17-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/oracle-graalvm-17/Dockerfile
+++ b/oracle-graalvm-17/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/oracle-graalvm-21-maven-4/Dockerfile
+++ b/oracle-graalvm-21-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/oracle-graalvm-21/Dockerfile
+++ b/oracle-graalvm-21/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/oracle-graalvm-24-maven-4/Dockerfile
+++ b/oracle-graalvm-24-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/oracle-graalvm-24/Dockerfile
+++ b/oracle-graalvm-24/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/oracle-graalvm-25-maven-4/Dockerfile
+++ b/oracle-graalvm-25-maven-4/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/oracle-graalvm-25/Dockerfile
+++ b/oracle-graalvm-25/Dockerfile
@@ -18,6 +18,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-17-maven-4/Dockerfile
+++ b/sapmachine-17-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-17/Dockerfile
+++ b/sapmachine-17/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-21-maven-4/Dockerfile
+++ b/sapmachine-21-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-21/Dockerfile
+++ b/sapmachine-21/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-25-maven-4/Dockerfile
+++ b/sapmachine-25-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-25/Dockerfile
+++ b/sapmachine-25/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-26-maven-4/Dockerfile
+++ b/sapmachine-26-maven-4/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]

--- a/sapmachine-26/Dockerfile
+++ b/sapmachine-26/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=maven_upstream /usr/local/bin/mvn-entrypoint.sh /usr/local/bin/mvn-e
 RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
 ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
+RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \
+  && mv "$MAVEN_CONFIG/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG/toolchains.xml"
 
 ENTRYPOINT ["/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["mvn"]


### PR DESCRIPTION
fixes #303

Created with
```
find . \( -name "Dockerfile" -or -name Dockerfile-template \) -not -path "*/\.*" -not -path \*/tests/Dockerfile|xargs sed -Ezi $'s/(\\nENTRYPOINT )/RUN mvn org.apache.maven.plugins:maven-toolchains-plugin:3.2.0:generate-jdk-toolchains-xml \\\\\\n  \\&\\& mv "$MAVEN_CONFIG\\/discovered-jdk-toolchains-cache.xml" "$MAVEN_CONFIG\\/toolchains.xml"\\n\\1/'
```