### PR TITLE
chore: bump windows JDK versions

### DIFF
--- a/amazoncorretto-8-windowsservercore/Dockerfile
+++ b/amazoncorretto-8-windowsservercore/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ARG zip=amazon-corretto-8-x64-windows-jdk.zip
 ARG uri=https://corretto.aws/downloads/latest
-ARG hash=c73109bd194b7c94041d984a98fded4be0c9aee75473c90a0e3b77f606d9b9b2
+ARG hash=eccce8d939f1abb9570812b09360a83eb4d0ec937e5bd2a78be158d8e6aeec2d
 
 RUN Invoke-WebRequest -Uri $('{0}/{1}' -f $env:uri,$env:zip) -OutFile C:/$env:zip ; `
     if((Get-FileHash C:/$env:zip -Algorithm SHA256).Hash.ToLower() -ne $env:hash) { `


### PR DESCRIPTION
Bumps Windows JDK versions, updating SHA256 hashes and JAVA_HOME paths.