### PR TITLE
chore: lock amazoncorretto images to al2023

### DIFF
--- a/amazoncorretto-11/Dockerfile
+++ b/amazoncorretto-11/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:3.9.16-eclipse-temurin-17 AS maven_upstream
 
 # EXTRA_TAG_SUFFIXES=al2023
-FROM amazoncorretto:11
+FROM amazoncorretto:11-al2023
 
 RUN yum install -y tar which gzip # TODO remove
 RUN yum install -y openssh-clients findutils

--- a/amazoncorretto-17-maven-4/Dockerfile
+++ b/amazoncorretto-17-maven-4/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 # EXTRA_TAG_SUFFIXES=al2023
-FROM amazoncorretto:17
+FROM amazoncorretto:17-al2023
 
 RUN yum install -y openssh-clients findutils
 

--- a/amazoncorretto-17/Dockerfile
+++ b/amazoncorretto-17/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:3.9.16-eclipse-temurin-17 AS maven_upstream
 
 # EXTRA_TAG_SUFFIXES=al2023
-FROM amazoncorretto:17
+FROM amazoncorretto:17-al2023
 
 RUN yum install -y tar which gzip # TODO remove
 RUN yum install -y openssh-clients findutils

--- a/amazoncorretto-21-maven-4/Dockerfile
+++ b/amazoncorretto-21-maven-4/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 # EXTRA_TAG_SUFFIXES=al2023
-FROM amazoncorretto:21
+FROM amazoncorretto:21-al2023
 
 RUN yum install -y openssh-clients findutils
 

--- a/amazoncorretto-21/Dockerfile
+++ b/amazoncorretto-21/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:3.9.16-eclipse-temurin-17 AS maven_upstream
 
 # EXTRA_TAG_SUFFIXES=al2023
-FROM amazoncorretto:21
+FROM amazoncorretto:21-al2023
 
 RUN yum install -y tar which gzip # TODO remove
 RUN yum install -y openssh-clients findutils

--- a/amazoncorretto-25-maven-4/Dockerfile
+++ b/amazoncorretto-25-maven-4/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:4.0.0-rc-5-eclipse-temurin-17 AS maven_upstream
 
 # EXTRA_TAG_SUFFIXES=al2023
-FROM amazoncorretto:25
+FROM amazoncorretto:25-al2023
 
 RUN yum install -y openssh-clients findutils
 

--- a/amazoncorretto-25/Dockerfile
+++ b/amazoncorretto-25/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:3.9.16-eclipse-temurin-17 AS maven_upstream
 
 # EXTRA_TAG_SUFFIXES=al2023
-FROM amazoncorretto:25
+FROM amazoncorretto:25-al2023
 
 RUN yum install -y openssh-clients findutils
 

--- a/amazoncorretto-8/Dockerfile
+++ b/amazoncorretto-8/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:3.9.16-eclipse-temurin-17 AS maven_upstream
 
 # EXTRA_TAG_SUFFIXES=al2023
-FROM amazoncorretto:8
+FROM amazoncorretto:8-al2023
 
 RUN yum install -y tar which gzip # TODO remove
 RUN yum install -y openssh-clients findutils


### PR DESCRIPTION
to prevent unintended upstream changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Amazon Corretto 8, 11, 17, 21, and 25 container images to use the Amazon Linux 2023 variants.
  * Applied the update across standard and Maven-enabled image configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->